### PR TITLE
Make all existing tests run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -10,9 +10,13 @@
     "url": "git://github.com/ramda/ramda-fantasy.git"
   },
   "scripts": {
+    "test": "mocha"
   },
-  "dependencies": {},
+  "dependencies": {
+    "ramda": "^0.9.1"
+  },
   "devDependencies": {
+    "mocha": "^2.1.0",
     "uglify-js": "2.4.x",
     "xyz": "0.5.x"
   }

--- a/src/IO.js
+++ b/src/IO.js
@@ -6,7 +6,7 @@
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like environments that support module.exports,
         // like Node.
-        module.exports = factory(require('../..'));
+        module.exports = factory(require('ramda'));
     } else {
         // Browser globals
         this.IO = factory(this.R);

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -6,7 +6,7 @@
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like environments that support module.exports,
         // like Node.
-        module.exports = factory(require('../..'));
+        module.exports = factory();
     } else {
         // Browser globals
         this.Reader = factory(this.R);

--- a/test/maybe.test.js
+++ b/test/maybe.test.js
@@ -1,3 +1,4 @@
+var R = require('ramda');
 var assert = require('assert');
 var types = require('./types');
 


### PR DESCRIPTION
All existing tests can now be executed by running npm test. Mocha was
installed as a devDependency and is used by the npm test script.

The IO type depends on ramda and because of this ramda was installed
as a dependency. This could later be removed if the purpose is to make
this package dependency free.

A .gitignore file was created which includes the node_modules folder.