### PR TITLE
Commonjsified all types

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,8 @@
+module.exports = {
+    Either: require('./src/Either'),
+    Future: require('./src/Future'),
+    Identity: require('./src/Identity'),
+    IO: require('./src/IO'),
+    Maybe: require('./src/Maybe'),
+    Reader: require('./src/Reader')
+};

--- a/src/Either.js
+++ b/src/Either.js
@@ -1,77 +1,61 @@
-(function(factory) {
-    if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(factory);
-    } else if (typeof exports === 'object') {
-        // Node. Does not work with strict CommonJS, but
-        // only CommonJS-like environments that support module.exports,
-        // like Node.
-        module.exports = factory();
+module.exports = Either;
+
+function F() {}
+
+function inherit(Parent, Child) {
+    if (Object.create) {
+        Child.prototype = Object.create(Parent.prototype);
     } else {
-        // Browser globals
-        this.Either = factory();
+        F.prototype = Parent.prototype;
+        Child.prototype = new F();
+        Child.prototype.constructor = Child;
     }
-}(function() {
+    return Child;
+}
 
-    function F() {}
-
-    function inherit(Parent, Child) {
-        if (Object.create) {
-            Child.prototype = Object.create(Parent.prototype);
-        } else {
-            F.prototype = Parent.prototype;
-            Child.prototype = new F();
-            Child.prototype.constructor = Child;
-        }
-        return Child;
-    }
-
-    function Either(left, right) {
-        switch (arguments.length) {
-            case 0:
-                throw new TypeError('no arguments to Either');
-            case 1:
-                return function(right) {
-                    return right == null ? Left(left) : Right(right);
-                };
-            default:
+function Either(left, right) {
+    switch (arguments.length) {
+        case 0:
+            throw new TypeError('no arguments to Either');
+        case 1:
+            return function(right) {
                 return right == null ? Left(left) : Right(right);
-        }
+            };
+        default:
+            return right == null ? Left(left) : Right(right);
     }
+}
 
-    function Right(value) {
-        if (!(this instanceof Right)) {
-            return new Right(value);
-        }
-        this.value = value;
+function Right(value) {
+    if (!(this instanceof Right)) {
+        return new Right(value);
     }
-    function Left(value) {
-        if (!(this instanceof Left)) {
-            return new Left(value);
-        }
-        this.value = value;
+    this.value = value;
+}
+function Left(value) {
+    if (!(this instanceof Left)) {
+        return new Left(value);
     }
+    this.value = value;
+}
 
-    function returnThis() { return this; }
+function returnThis() { return this; }
 
-    Either.Right = Right;
-    Either.Left = Left;
+Either.Right = Right;
+Either.Left = Left;
 
-    Either.prototype.map = returnThis;
-    Either.of = Either.prototype.of = function(value) { return new Right(value); };
-    Either.prototype.chain = returnThis; // throw
-    Either.equals = Either.prototype.equals = function(that) {
-        return this.constructor === that.constructor && this.value === that.value;
-    };
+Either.prototype.map = returnThis;
+Either.of = Either.prototype.of = function(value) { return new Right(value); };
+Either.prototype.chain = returnThis; // throw
+Either.equals = Either.prototype.equals = function(that) {
+    return this.constructor === that.constructor && this.value === that.value;
+};
 
-    inherit(Either, Right);
-    inherit(Either, Left);
+inherit(Either, Right);
+inherit(Either, Left);
 
-    Right.prototype.map = function(fn) { return new Right(fn(this.value)); };
-    Right.prototype.ap = function(that) { return that.map(this.value); };
-    Right.prototype.chain = function(f) { return f(this.value); };
+Right.prototype.map = function(fn) { return new Right(fn(this.value)); };
+Right.prototype.ap = function(that) { return that.map(this.value); };
+Right.prototype.chain = function(f) { return f(this.value); };
 
-    Left.prototype.ap = function(that) { return that; };
-
-    return Either;
-}));
+Left.prototype.ap = function(that) { return that; };

--- a/src/Future.js
+++ b/src/Future.js
@@ -1,64 +1,49 @@
-(function(factory) {
-    if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(factory);
-    } else if (typeof exports === 'object') {
-        // Node. Does not work with strict CommonJS, but
-        // only CommonJS-like environments that support module.exports,
-        // like Node.
-        module.exports = factory();
-    } else {
-        // Browser globals
-        this.Future = factory();
+module.exports = Future;
+
+// `f` is a function that takes two function arguments: `reject` (failure) and `resolve` (success)
+function Future(f) {
+    if (!(this instanceof Future)) {
+        return new Future(f);
     }
-}(function() {
-    // `f` is a function that takes two function arguments: `reject` (failure) and `resolve` (success)
-    function Future(f) {
-        if (!(this instanceof Future)) {
-            return new Future(f);
-        }
-        this.fork = f;
-    }
+    this.fork = f;
+}
 
-    // functor
-    Future.prototype.map = function(f) {
-        return this.chain(function(a) { return Future.of(f(a)); });
-    };
+// functor
+Future.prototype.map = function(f) {
+    return this.chain(function(a) { return Future.of(f(a)); });
+};
 
-    // apply
-    Future.prototype.ap = function(m) {
-        return this.chain(function(f) { return m.map(f); });
-    };
+// apply
+Future.prototype.ap = function(m) {
+    return this.chain(function(f) { return m.map(f); });
+};
 
-    // applicative
-    Future.of = function(x) {
-        // should include a default rejection?
-        return new Future(function(_, resolve) { return resolve(x); });
-    };
+// applicative
+Future.of = function(x) {
+    // should include a default rejection?
+    return new Future(function(_, resolve) { return resolve(x); });
+};
 
-    Future.prototype.of = Future.of;
+Future.prototype.of = Future.of;
 
-    // chain
-    //  f must be a function which returns a value
-    //  f must return a value of the same Chain
-    //  chain must return a value of the same Chain
-    Future.prototype.chain = function(f) {  // Sorella's:
-        return new Future(function(reject, resolve) {
-            return this.fork(function(a) { return reject(a); },
-                             function(b) { return f(b).fork(reject, resolve); });
-        }.bind(this));
-    };
+// chain
+//  f must be a function which returns a value
+//  f must return a value of the same Chain
+//  chain must return a value of the same Chain
+Future.prototype.chain = function(f) {  // Sorella's:
+    return new Future(function(reject, resolve) {
+        return this.fork(function(a) { return reject(a); },
+                         function(b) { return f(b).fork(reject, resolve); });
+    }.bind(this));
+};
 
-    // monad
-    // A value that implements the Monad specification must also implement the Applicative and Chain specifications.
-    // see above.
+// monad
+// A value that implements the Monad specification must also implement the Applicative and Chain specifications.
+// see above.
 
-    // equality method to enable testing
-    Future.prototype.equals = function(that) {
-        void that;
-        // TODO: how do you define equality for two Futures?
-        return true;
-    };
-
-    return Future;
-}));
+// equality method to enable testing
+Future.prototype.equals = function(that) {
+    void that;
+    // TODO: how do you define equality for two Futures?
+    return true;
+};

--- a/src/IO.js
+++ b/src/IO.js
@@ -1,67 +1,54 @@
-(function(factory) {
-    if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(['ramda'], factory);
-    } else if (typeof exports === 'object') {
-        // Node. Does not work with strict CommonJS, but
-        // only CommonJS-like environments that support module.exports,
-        // like Node.
-        module.exports = factory(require('ramda'));
-    } else {
-        // Browser globals
-        this.IO = factory(this.R);
+var R = require('ramda');
+
+module.exports = IO;
+
+var compose = R.compose;
+
+function IO(fn) {
+    if (!(this instanceof IO)) {
+        return new IO(fn);
     }
-}(function(R) {
-    var compose = R.compose;
+    this.fn = fn;
+}
 
-    function IO(fn) {
-        if (!(this instanceof IO)) {
-            return new IO(fn);
-        }
-        this.fn = fn;
-    }
+// `f` must return an IO
+IO.prototype.chain = function(f) {
+    var io = this;
+    return new IO(function() {
+        return f(io.fn()).fn();
+    });
+};
 
-    // `f` must return an IO
-    IO.prototype.chain = function(f) {
-        var io = this;
-        return new IO(function() {
-            return f(io.fn()).fn();
-        });
-    };
+IO.prototype.map = function(f) {
+    var io = this;
+    return new IO(compose(f, io.fn));
+};
 
-    IO.prototype.map = function(f) {
-        var io = this;
-        return new IO(compose(f, io.fn));
-    };
+// `this` IO must wrap a function `f` that takes an IO (`thatIo`) as input
+// `f` must return an IO
+IO.prototype.ap = function(thatIo) {
+    return this.chain(function(f) {
+        return thatIo.map(f);
+    });
+};
 
-    // `this` IO must wrap a function `f` that takes an IO (`thatIo`) as input
-    // `f` must return an IO
-    IO.prototype.ap = function(thatIo) {
-        return this.chain(function(f) {
-            return thatIo.map(f);
-        });
-    };
+IO.runIO = function(io) {
+    return io.runIO.apply(io, [].slice.call(arguments, 1));
+};
 
-    IO.runIO = function(io) {
-        return io.runIO.apply(io, [].slice.call(arguments, 1));
-    };
+IO.prototype.runIO = function() {
+    return this.fn.apply(this, arguments);
+};
 
-    IO.prototype.runIO = function() {
-        return this.fn.apply(this, arguments);
-    };
+IO.prototype.of = function(x) {
+    return new IO(function() { return x; });
+};
 
-    IO.prototype.of = function(x) {
-        return new IO(function() { return x; });
-    };
+IO.of = IO.prototype.of;
 
-    IO.of = IO.prototype.of;
-
-    // this is really only to accommodate testing ....
-    IO.prototype.equals = function(that) {
-        return this === that ||
-            this.fn === that.fn ||
-            IO.runIO(this) === IO.runIO(that);
-    };
-
-    return IO;
-}));
+// this is really only to accommodate testing ....
+IO.prototype.equals = function(that) {
+    return this === that ||
+        this.fn === that.fn ||
+        IO.runIO(this) === IO.runIO(that);
+};

--- a/src/Identity.js
+++ b/src/Identity.js
@@ -1,95 +1,79 @@
-(function(factory) {
-    if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(factory);
-    } else if (typeof exports === 'object') {
-        // Node. Does not work with strict CommonJS, but
-        // only CommonJS-like environments that support module.exports,
-        // like Node.
-        module.exports = factory();
-    } else {
-        // Browser globals
-        this.Identity = factory();
-    }
-}(function() {
+module.exports = Identity;
 
-    /**
-     * A data type that holds a value and exposes a monadic api.
-     */
+/**
+ * A data type that holds a value and exposes a monadic api.
+ */
 
-    /**
-     * Constructs a new `Identity[a]` data type that holds a single
-     * value `a`.
-     * @param {*} a Value of any type
-     * @sig a -> Identity[a]
-     */
-    function Identity(x) {
-        if (!(this instanceof Identity)) {
-            return new Identity(x);
-        }
-        this.value = x;
-    }
-
-    /**
-     * Applicative specification. Creates a new `Identity[a]` holding the value `a`.
-     * @param {*} a Value of any type
-     * @returns Identity[a]
-     * @sig a -> Identity[a]
-     */
-    Identity.of = function(x) {
+/**
+ * Constructs a new `Identity[a]` data type that holds a single
+ * value `a`.
+ * @param {*} a Value of any type
+ * @sig a -> Identity[a]
+ */
+function Identity(x) {
+    if (!(this instanceof Identity)) {
         return new Identity(x);
-    };
-    Identity.prototype.of = Identity.of;
+    }
+    this.value = x;
+}
 
-    /**
-     * Functor specification. Creates a new `Identity[a]` mapping function `f` onto
-     * `a` returning any value b.
-     * @param {Function} f Maps `a` to any value `b`
-     * @returns Identity[b]
-     * @sig @Identity[a] => (a -> b) -> Identity[b]
-     */
-    Identity.prototype.map = function(f) {
-        return new Identity(f(this.value));
-    };
+/**
+ * Applicative specification. Creates a new `Identity[a]` holding the value `a`.
+ * @param {*} a Value of any type
+ * @returns Identity[a]
+ * @sig a -> Identity[a]
+ */
+Identity.of = function(x) {
+    return new Identity(x);
+};
+Identity.prototype.of = Identity.of;
 
-    /**
-     * Apply specification. Applies the function inside the `Identity[a]`
-     * type to another applicative type.
-     * @param {Applicative[a]} app Applicative that will apply its function
-     * @returns Applicative[b]
-     * @sig (Identity[a -> b], f: Applicative[_]) => f[a] -> f[b]
-     */
-    Identity.prototype.ap = function(app) {
-        return app.map(this.value);
-    };
+/**
+ * Functor specification. Creates a new `Identity[a]` mapping function `f` onto
+ * `a` returning any value b.
+ * @param {Function} f Maps `a` to any value `b`
+ * @returns Identity[b]
+ * @sig @Identity[a] => (a -> b) -> Identity[b]
+ */
+Identity.prototype.map = function(f) {
+    return new Identity(f(this.value));
+};
 
-    /**
-     * Chain specification. Transforms the value of the `Identity[a]`
-     * type using an unary function to monads. The `Identity[a]` type
-     * should contain a function, otherwise an error is thrown.
-     *
-     * @param {Function} fn Transforms `a` into a `Monad[b]`
-     * @returns Monad[b]
-     * @sig (Identity[a], m: Monad[_]) => (a -> m[b]) -> m[b]
-     */
-    Identity.prototype.chain = function(fn) {
-        return fn(this.value);
-    };
+/**
+ * Apply specification. Applies the function inside the `Identity[a]`
+ * type to another applicative type.
+ * @param {Applicative[a]} app Applicative that will apply its function
+ * @returns Applicative[b]
+ * @sig (Identity[a -> b], f: Applicative[_]) => f[a] -> f[b]
+ */
+Identity.prototype.ap = function(app) {
+    return app.map(this.value);
+};
 
-    /**
-     * Returns the value of `Identity[a]`
-     *
-     * @returns a
-     * @sig (Identity[a]) => a
-     */
-    Identity.prototype.get = function() {
-        return this.value;
-    };
+/**
+ * Chain specification. Transforms the value of the `Identity[a]`
+ * type using an unary function to monads. The `Identity[a]` type
+ * should contain a function, otherwise an error is thrown.
+ *
+ * @param {Function} fn Transforms `a` into a `Monad[b]`
+ * @returns Monad[b]
+ * @sig (Identity[a], m: Monad[_]) => (a -> m[b]) -> m[b]
+ */
+Identity.prototype.chain = function(fn) {
+    return fn(this.value);
+};
 
-    // equality method to enable testing
-    Identity.prototype.equals = function(that) {
-        return this.value === that.value;
-    };
+/**
+ * Returns the value of `Identity[a]`
+ *
+ * @returns a
+ * @sig (Identity[a]) => a
+ */
+Identity.prototype.get = function() {
+    return this.value;
+};
 
-    return Identity;
-}));
+// equality method to enable testing
+Identity.prototype.equals = function(that) {
+    return this.value === that.value;
+};

--- a/src/Maybe.js
+++ b/src/Maybe.js
@@ -1,60 +1,45 @@
-(function(factory) {
-    if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(factory);
-    } else if (typeof exports === 'object') {
-        // Node. Does not work with strict CommonJS, but
-        // only CommonJS-like environments that support module.exports,
-        // like Node.
-        module.exports = factory();
-    } else {
-        // Browser globals
-        this.Maybe = factory();
-    }
-}(function() {
-    function Maybe(x) {
-        if (!(this instanceof Maybe)) {
-            return new Maybe(x);
-        }
-        this.value = x;
-    }
+module.exports = Maybe;
 
-    Maybe.of = function(x) {
+function Maybe(x) {
+    if (!(this instanceof Maybe)) {
         return new Maybe(x);
-    };
+    }
+    this.value = x;
+};
 
-    // functor
-    Maybe.prototype.map = function(f) {
-        return this.value == null ? this : new Maybe(f(this.value));
-    };
+Maybe.of = function(x) {
+    return new Maybe(x);
+};
 
-    // apply
-    // takes a Maybe that wraps a function (`app`) and applies its `map`
-    // method to this Maybe's value, which must be a function.
-    Maybe.prototype.ap = function(m) {
-        return typeof this.value !== 'function' ? new Maybe(null) : m.map(this.value);
-    };
+// functor
+Maybe.prototype.map = function(f) {
+    return this.value == null ? this : new Maybe(f(this.value));
+};
 
-    // applicative
-    Maybe.prototype.of = Maybe.of;
+// apply
+// takes a Maybe that wraps a function (`app`) and applies its `map`
+// method to this Maybe's value, which must be a function.
+Maybe.prototype.ap = function(m) {
+    return typeof this.value !== 'function' ? new Maybe(null) : m.map(this.value);
+};
 
-    // chain
-    //  f must be a function which returns a value
-    //  f must return a value of the same Chain
-    //  chain must return a value of the same Chain
-    //
-    Maybe.prototype.chain = function(f) {
-        return this.value == null ? this : f(this.value);
-    };
+// applicative
+Maybe.prototype.of = Maybe.of;
 
-    // monad
-    // A value that implements the Monad specification must also implement the Applicative and Chain specifications.
-    // see above.
+// chain
+//  f must be a function which returns a value
+//  f must return a value of the same Chain
+//  chain must return a value of the same Chain
+//
+Maybe.prototype.chain = function(f) {
+    return this.value == null ? this : f(this.value);
+};
 
-    // equality method to enable testing
-    Maybe.prototype.equals = function(that) {
-        return this.value === that.value;
-    };
+// monad
+// A value that implements the Monad specification must also implement the Applicative and Chain specifications.
+// see above.
 
-    return Maybe;
-}));
+// equality method to enable testing
+Maybe.prototype.equals = function(that) {
+    return this.value === that.value;
+};

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -1,67 +1,52 @@
-(function(factory) {
-    if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(['ramda'], factory);
-    } else if (typeof exports === 'object') {
-        // Node. Does not work with strict CommonJS, but
-        // only CommonJS-like environments that support module.exports,
-        // like Node.
-        module.exports = factory();
-    } else {
-        // Browser globals
-        this.Reader = factory(this.R);
+module.exports = Reader;
+
+function Reader(fn) {
+    if (!(this instanceof Reader)) {
+        return new Reader(fn);
     }
-}(function() {
+    this.fn = fn;
+}
 
-    function Reader(fn) {
-        if (!(this instanceof Reader)) {
-            return new Reader(fn);
-        }
-        this.fn = fn;
-    }
+Reader.run = function(reader) {
+    return reader.run.apply(reader, [].slice.call(arguments, 1));
+};
 
-    Reader.run = function(reader) {
-        return reader.run.apply(reader, [].slice.call(arguments, 1));
-    };
+Reader.prototype.run = function() {
+    return this.fn.apply(this, arguments);
+};
 
-    Reader.prototype.run = function() {
-        return this.fn.apply(this, arguments);
-    };
+Reader.prototype.chain = function(f) {
+    var reader = this;
+    return new Reader(function() {
+        return f(reader.fn()).fn();
+    });
+};
 
-    Reader.prototype.chain = function(f) {
-        var reader = this;
-        return new Reader(function() {
-            return f(reader.fn()).fn();
-        });
-    };
+Reader.prototype.ap = function(a) {
+    return this.chain(function(f) {
+        return a.map(f);
+    });
+};
 
-    Reader.prototype.ap = function(a) {
-        return this.chain(function(f) {
-            return a.map(f);
-        });
-    };
+Reader.prototype.map = function(f) {
+    return this.chain(function(a) {
+        return Reader.of(f(a));
+    });
+};
 
-    Reader.prototype.map = function(f) {
-        return this.chain(function(a) {
-            return Reader.of(f(a));
-        });
-    };
-
-    Reader.prototype.of = function(a) {
-        return new Reader(function() {
-            return a;
-        });
-    };
-    Reader.of = Reader.prototype.of;
-
-    Reader.ask = Reader(function(a) {
+Reader.prototype.of = function(a) {
+    return new Reader(function() {
         return a;
     });
+};
+Reader.of = Reader.prototype.of;
 
-    Reader.prototype.equals = function(that) {
-        return this === that ||
-        this.fn === that.fn ||
-        Reader.run(this) === Reader.run(that);
-    };
-    return Reader;
-}));
+Reader.ask = Reader(function(a) {
+    return a;
+});
+
+Reader.prototype.equals = function(that) {
+    return this === that ||
+    this.fn === that.fn ||
+    Reader.run(this) === Reader.run(that);
+};

--- a/test/either.test.js
+++ b/test/either.test.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var types = require('./types');
 
-var Either = require('../src/Either');
+var Either = require('..').Either;
 
 describe('Either', function() {
     var e = Either('original left', 1);

--- a/test/identity.test.js
+++ b/test/identity.test.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var types = require('./types');
 
-var Identity = require('../src/Identity');
+var Identity = require('..').Identity;
 
 describe('Identity', function() {
     var m = Identity(1);

--- a/test/io.test.js
+++ b/test/io.test.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var types = require('./types');
 
-var IO = require('../src/IO');
+var IO = require('..').IO;
 
 function add(a) {
     return function(b) { return a + b; };

--- a/test/maybe.test.js
+++ b/test/maybe.test.js
@@ -2,7 +2,7 @@ var R = require('ramda');
 var assert = require('assert');
 var types = require('./types');
 
-var Maybe = require('../src/Maybe');
+var Maybe = require('..').Maybe;
 
 describe('Maybe', function() {
     var m = Maybe(1);

--- a/test/reader.test.js
+++ b/test/reader.test.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var types = require('./types');
 
-var Reader = require('../src/Reader');
+var Reader = require('..').Reader;
 
 function add(a) {
       return function(b) { return a + b; };


### PR DESCRIPTION
All the existing types has been converted to the common js format. An
index file has been created that exposes makes them possible to import
like this:
```
var Maybe = require('ramda-fantasy').Maybe;
```

The tests now use these imports, all tests pass.