### PR TITLE
Remove run from Reader prototype and make it an instance attribute

### DIFF
--- a/src/Reader.js
+++ b/src/Reader.js
@@ -1,24 +1,20 @@
 module.exports = Reader;
 
-function Reader(fn) {
+function Reader(run) {
     if (!(this instanceof Reader)) {
-        return new Reader(fn);
+        return new Reader(run);
     }
-    this.fn = fn;
+    this.run = run;
 }
 
 Reader.run = function(reader) {
     return reader.run.apply(reader, [].slice.call(arguments, 1));
 };
 
-Reader.prototype.run = function() {
-    return this.fn.apply(this, arguments);
-};
-
 Reader.prototype.chain = function(f) {
     var reader = this;
     return new Reader(function() {
-        return f(reader.fn()).fn();
+        return f(reader.run()).run();
     });
 };
 
@@ -47,6 +43,6 @@ Reader.ask = Reader(function(a) {
 
 Reader.prototype.equals = function(that) {
     return this === that ||
-    this.fn === that.fn ||
+    this.run === that.run ||
     Reader.run(this) === Reader.run(that);
 };


### PR DESCRIPTION
The `run` method on the Reader prototype was only delegating to the
internal function supplied to the constructor. A better solution for
this is to simply name the input function `run`. No need to use
`fn.call(this, arguments)`. Tests still pass.