### PR TITLE
Fix `Reader`.

### DIFF
--- a/src/Reader.js
+++ b/src/Reader.js
@@ -13,8 +13,8 @@ Reader.run = function(reader) {
 
 Reader.prototype.chain = function(f) {
     var reader = this;
-    return new Reader(function() {
-        return f(reader.run()).run();
+    return new Reader(function(r) {
+        return f(reader.run(r)).run(r);
     });
 };
 


### PR DESCRIPTION
Don't merge this yet.

So, the tests pass before and after this change, but this is a fairly huge change as far as semantics go. Before, it wasn't a `Functor`, `Apply`, `Chain`, or `Monad` (as all of the functions depended on `chain` working properly), now it "should" be. I say "should" because I'm not actually sure this fix actually fixed it. This tells me that the tests aren't actually testing the semantics here, so we should discuss what should change such that the tests work properly.

I have not looked at the tests yet to see where the failure is. Maybe someone can provide some insight.