### PR TITLE
Make Future.ap run in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "ramda": "^0.10.0"
+    "ramda": "^0.13.0"
   },
   "devDependencies": {
     "jsverify": "^0.5.1",


### PR DESCRIPTION
This change to `ap` for Futures does not wait for its own fork to be
resolved before forking the input furture. The effect is, among other
things, that `lift` can be used in order to call a method with the
result of several futures that have been resolved in parallel.