### PR TITLE
Add reject to Future

### DIFF
--- a/src/Future.js
+++ b/src/Future.js
@@ -64,3 +64,9 @@ Future.prototype.chain = function(f) {  // Sorella's:
 // monad
 // A value that implements the Monad specification must also implement the Applicative and Chain specifications.
 // see above.
+
+Future.reject = function(val) {
+    return new Future(function(reject, _) {
+        reject(val);
+    });
+};

--- a/test/future.test.js
+++ b/test/future.test.js
@@ -144,6 +144,21 @@ describe('Future', function() {
         var f2 = delayError(10, 'secondError');
         f1.map(add).ap(f2).fork(assertCbVal(done, 'secondError'));
       });
+
+    });
+
+    describe('reject', function() {
+
+      it('creates a rejected future with the given value', function() {
+        var f = Future.reject('foo');
+        var forked;
+        f.fork(function(err) {
+          forked = true;
+          assert.equal('foo', err);
+        });
+        assert.equal(true, forked);
+      });
+
     });
 
 });


### PR DESCRIPTION
Complement function to `of`. Creates a future that will be rejected with
the input value.