### PR TITLE
Add liftA2 and liftA3

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ module.exports = {
     Future: require('./src/Future'),
     Identity: require('./src/Identity'),
     IO: require('./src/IO'),
+    lift2: require('./src/lift2'),
+    lift3: require('./src/lift3'),
     Maybe: require('./src/Maybe'),
     Tuple: require('./src/Tuple'),
     Reader: require('./src/Reader')

--- a/src/lift2.js
+++ b/src/lift2.js
@@ -1,0 +1,5 @@
+var R = require('ramda');
+
+module.exports = R.curryN(3, function liftA2(f, a1, a2) {
+  return a1.map(f).ap(a2);
+});

--- a/src/lift3.js
+++ b/src/lift3.js
@@ -1,0 +1,5 @@
+var R = require('ramda');
+
+module.exports = R.curryN(4, function liftA2(f, a1, a2, a3) {
+  return a1.map(f).ap(a2).ap(a3);
+});

--- a/test/lift2.test.js
+++ b/test/lift2.test.js
@@ -1,0 +1,23 @@
+var lift2 = require('../src/lift2');
+var Identity = require('../src/Identity');
+var R = require('ramda');
+var assert = require('assert');
+
+describe('lift2', function() {
+
+  var i1 = Identity.of(1);
+  var i2 = Identity.of(2);
+
+  it('lifts the values of two applys into a curried function', function() {
+    var result = lift2(R.add, i1, i2);
+    assert.equal(true, Identity.of(3).equals(result));
+  });
+
+  it('is itself curried', function() {
+    var step1 = lift2(R.add);
+    var step2 = step1(i1);
+    var result = step2(i2);
+    assert.equal(true, Identity.of(3).equals(result));
+  });
+
+});

--- a/test/lift3.test.js
+++ b/test/lift3.test.js
@@ -1,0 +1,29 @@
+var lift3 = require('../src/lift3');
+var Identity = require('../src/Identity');
+var R = require('ramda');
+var assert = require('assert');
+
+describe('lift3', function() {
+
+  var combine3 = R.curry(function(a, b, c) {
+    return [ a, b, c ].join(' ');
+  })
+
+  var i1 = Identity.of('foo');
+  var i2 = Identity.of('bar');
+  var i3 = Identity.of('baz');
+
+  it('lifts the values of three applys into a curried function', function() {
+    var result = lift3(combine3, i1, i2, i3);
+    assert.equal(true, Identity.of('foo bar baz').equals(result));
+  });
+
+  it('is itself curried', function() {
+    var step1 = lift3(combine3);
+    var step2 = step1(i1);
+    var step3 = step2(i2);
+    var result = step3(i3);
+    assert.equal(true, Identity.of('foo bar baz').equals(result));
+  });
+
+});


### PR DESCRIPTION
The lift function specifically implemented for fantasy land compatible
types. Comes in two versions, for functions of airity 2 and 3.