### PR TITLE
fixed a typo

### DIFF
--- a/src/lift3.js
+++ b/src/lift3.js
@@ -1,5 +1,5 @@
 var R = require('ramda');
 
-module.exports = R.curryN(4, function liftA2(f, a1, a2, a3) {
+module.exports = R.curryN(4, function liftA3(f, a1, a2, a3) {
   return a1.map(f).ap(a2).ap(a3);
 });


### PR DESCRIPTION
Not a big deal but I think the we had a little copy/past action here. liftA3 was called liftA2.