### PR TITLE
Loosen up timeout for Future#ap parallel test

### DIFF
--- a/test/future.test.js
+++ b/test/future.test.js
@@ -116,7 +116,7 @@ describe('Future', function() {
       });
 
       it('does the apply in parallel', function(done) {
-        this.timeout(20);
+        this.timeout(25);
         var f1 = delayValue(15, 1);
         var f2 = delayValue(15, 2);
         f1.map(add).ap(f2).fork(null, assertCbVal(done, 3));


### PR DESCRIPTION
The test always fails for me because it apparently just won't finish within the 20ms timeout. Raising it to 25ms fixed it for me and since 2*15 > 25 this stills proofs non-sequential execution.