### PR TITLE
define "toString" method for each constructor

### DIFF
--- a/src/Either.js
+++ b/src/Either.js
@@ -1,3 +1,5 @@
+var R = require('ramda');
+
 var util = require('./internal/util');
 
 
@@ -51,6 +53,10 @@ _Right.prototype.extend = function(f) {
   return new _Right(f(this));
 };
 
+_Right.prototype.toString = function() {
+  return 'Either.Right(' + R.toString(this.value) + ')';
+};
+
 Either.Right = function(value) {
   return new _Right(value);
 };
@@ -69,6 +75,10 @@ _Left.prototype.bimap = function(f) {
 };
 
 _Left.prototype.extend = util.returnThis;
+
+_Left.prototype.toString = function() {
+  return 'Either.Left(' + R.toString(this.value) + ')';
+};
 
 Either.Left = function(value) {
   return new _Left(value);

--- a/src/Future.js
+++ b/src/Future.js
@@ -81,4 +81,8 @@ Future.reject = function(val) {
   });
 };
 
+Future.prototype.toString = function() {
+  return 'Future(' + R.toString(this.fork) + ')';
+};
+
 module.exports = Future;

--- a/src/IO.js
+++ b/src/IO.js
@@ -52,3 +52,7 @@ IO.prototype.equals = function(that) {
     this.fn === that.fn ||
     R.eqDeep(IO.runIO(this), IO.runIO(that));
 };
+
+IO.prototype.toString = function() {
+  return 'IO(' + R.toString(this.fn) + ')';
+};

--- a/src/Identity.js
+++ b/src/Identity.js
@@ -1,3 +1,5 @@
+var R = require('ramda');
+
 var util = require('./internal/util');
 
 
@@ -76,5 +78,9 @@ Identity.prototype.get = function() {
 
 // equality method to enable testing
 Identity.prototype.equals = util.getEquals(Identity);
+
+Identity.prototype.toString = function() {
+  return 'Identity(' + R.toString(this.value) + ')';
+};
 
 module.exports = Identity;

--- a/src/Maybe.js
+++ b/src/Maybe.js
@@ -1,3 +1,5 @@
+var R = require('ramda');
+
 var util = require('./internal/util.js');
 
 function Maybe(x) {
@@ -93,6 +95,14 @@ _Just.prototype.getOrElse = function() {
 
 _Nothing.prototype.getOrElse = function(a) {
   return a;
+};
+
+_Just.prototype.toString = function() {
+  return 'Maybe.Just(' + R.toString(this.value) + ')';
+};
+
+_Nothing.prototype.toString = function() {
+  return 'Maybe.Nothing()';
 };
 
 module.exports = Maybe;

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -48,4 +48,8 @@ Reader.prototype.equals = function(that) {
   R.eqDeep(Reader.run(this), Reader.run(that));
 };
 
+Reader.prototype.toString = function() {
+  return 'Reader(' + R.toString(this.run) + ')';
+};
+
 module.exports = Reader;

--- a/src/Tuple.js
+++ b/src/Tuple.js
@@ -1,4 +1,4 @@
-var eqDeep = require('ramda').eqDeep;
+var R = require('ramda');
 
 
 function Tuple(x, y) {
@@ -23,8 +23,7 @@ function _Tuple(x, y) {
 function ensureConcat(xs) {
   xs.forEach(function(x) {
     if (typeof x.concat != 'function') {
-      var display = x.show ? x.show() : x;
-      throw new TypeError(display + ' must be a semigroup to perform this operation');
+      throw new TypeError(R.toString(x) + ' must be a semigroup to perform this operation');
     }
   });
 }
@@ -64,12 +63,11 @@ _Tuple.prototype.ap = function(m) {
 
 // setoid
 _Tuple.prototype.equals = function(that) {
-  return that instanceof _Tuple && eqDeep(this[0], that[0]) && eqDeep(this[1], that[1]);
+  return that instanceof _Tuple && R.eqDeep(this[0], that[0]) && R.eqDeep(this[1], that[1]);
 };
 
-// show - not recursive yet.
-_Tuple.prototype.show = function() {
-  return 'Tuple(' + this[0] + ', ' + this[1] + ')';
+_Tuple.prototype.toString = function() {
+  return 'Tuple(' + R.toString(this[0]) + ', ' + R.toString(this[1]) + ')';
 };
 
 module.exports = Tuple;

--- a/test/either.test.js
+++ b/test/either.test.js
@@ -84,4 +84,18 @@ describe('Either', function() {
 
   });
 
+  describe('#toString', function() {
+
+    it('returns the string representation of a Left', function() {
+      assert.strictEqual(Either.Left('Cannot divide by zero').toString(),
+                         'Either.Left("Cannot divide by zero")');
+    });
+
+    it('returns the string representation of a Right', function() {
+      assert.strictEqual(Either.Right([1, 2, 3]).toString(),
+                         'Either.Right([1, 2, 3])');
+    });
+
+  });
+
 });

--- a/test/future.test.js
+++ b/test/future.test.js
@@ -182,5 +182,16 @@ describe('Future', function() {
 
   });
 
+  describe('#toString', function() {
+
+    it('returns the string representation of a Future', function() {
+      assert.strictEqual(
+        Future(function(reject, resolve) { void resolve; }).toString(),
+        'Future(function (reject, resolve) { void resolve; })'
+      );
+    });
+
+  });
+
 });
 

--- a/test/identity.test.js
+++ b/test/identity.test.js
@@ -60,6 +60,18 @@ describe('Identity', function() {
     var mTest = types.monad;
     assert.equal(true, mTest.iface(m));
   });
+
+  describe('#toString', function() {
+
+    it('returns the string representation of an Identity', function() {
+      assert.strictEqual(Identity([1, 2, 3]).toString(),
+                         'Identity([1, 2, 3])');
+      assert.strictEqual(Identity(Identity('abc')).toString(),
+                         'Identity(Identity("abc"))');
+    });
+
+  });
+
 });
 
 describe('Identity example', function() {

--- a/test/io.test.js
+++ b/test/io.test.js
@@ -88,4 +88,13 @@ describe('IO', function() {
     assert.equal(true, mTest.iface(i1));
   });
 
+  describe('#toString', function() {
+
+    it('returns the string representation of an IO', function() {
+      assert.strictEqual(IO(function() {}).toString(),
+                         'IO(function () {})');
+    });
+
+  });
+
 });

--- a/test/maybe.test.js
+++ b/test/maybe.test.js
@@ -117,4 +117,18 @@ describe('Maybe usage', function() {
 
   });
 
+  describe('#toString', function() {
+
+    it('returns the string representation of a Just', function() {
+      assert.strictEqual(Maybe.Just([1, 2, 3]).toString(),
+                         'Maybe.Just([1, 2, 3])');
+    });
+
+    it('returns the string representation of a Nothing', function() {
+      assert.strictEqual(Maybe.Nothing().toString(),
+                         'Maybe.Nothing()');
+    });
+
+  });
+
 });

--- a/test/reader.test.js
+++ b/test/reader.test.js
@@ -73,6 +73,15 @@ describe('Reader properties', function() {
     assert.equal(true, mTest.iface(r1));
   });
 
+  describe('#toString', function() {
+
+    it('returns the string representation of a Reader', function() {
+      assert.strictEqual(Reader(function(x) { void x; }).toString(),
+                         'Reader(function (x) { void x; })');
+    });
+
+  });
+
 });
 
 describe('Reader examples', function() {

--- a/test/tuple.test.js
+++ b/test/tuple.test.js
@@ -180,4 +180,15 @@ describe('Tuple usage', function() {
     });
   });
 
+  describe('#toString', function() {
+
+    it('returns the string representation of a Tuple', function() {
+      assert.strictEqual(Tuple('abc', [1, 2, 3]).toString(),
+                         'Tuple("abc", [1, 2, 3])');
+      assert.strictEqual(Tuple('abc', Tuple(1, 2)).toString(),
+                         'Tuple("abc", Tuple(1, 2))');
+    });
+
+  });
+
 });


### PR DESCRIPTION
This makes ramda-fantasy types compatible with [`R.toString`][1].

Should I update this pull request to remove the `show` method from __Tuple.js__?


[1]: http://ramdajs.com/docs/#toString
