### PR TITLE
Adding chainReject for chaining operations off of failure cases. 

### DIFF
--- a/src/Future.js
+++ b/src/Future.js
@@ -53,10 +53,22 @@ Future.prototype.of = Future.of;
 //  f must be a function which returns a value
 //  f must return a value of the same Chain
 //  chain must return a value of the same Chain
+//:: Future a, b => (b -> Future c) -> Future c
 Future.prototype.chain = function(f) {  // Sorella's:
   return new Future(function(reject, resolve) {
     return this.fork(function(a) { return reject(a); },
                      function(b) { return f(b).fork(reject, resolve); });
+  }.bind(this));
+};
+
+// chainReject
+// Like chain but operates on the reject instead of the resolve case.
+//:: Future a, b => (a -> Future c) -> Future c
+Future.prototype.chainReject = function(f) {
+  return new Future(function(reject, resolve) {
+    return this.fork(function(a) { return f(a).fork(reject, resolve); },
+                     function(b) { return resolve(b);
+    });
   }.bind(this));
 };
 

--- a/test/future.test.js
+++ b/test/future.test.js
@@ -86,6 +86,14 @@ describe('Future', function() {
     assert.equal(true, Future.of(2).equals(result));
   });
 
+  describe('chainReject', function() {
+    it('.chainReject should work like chain but off reject case', function() {
+      var f1 = Future.reject(2);
+      var f2 = function(val){ return Future.of(val + 3);};
+      assert.equal(true, Future.of(5).equals(f1.chainReject(f2)));
+    });
+  });
+
   describe('#ap', function() {
     /*jshint browser:true */
     var add = R.add;


### PR DESCRIPTION
e.g. If you make a ajax request and you want to process error data differently than success data.

This is Task::orElse in folktale's data.task