### PR TITLE
Adds Reader Transformer

### DIFF
--- a/test/types.js
+++ b/test/types.js
@@ -7,8 +7,11 @@ var interfaces = {
   chain:          ['map', 'ap', 'chain'],
   monad:          ['map', 'ap', 'chain', 'of'],
   extend:         ['extend'],
-  foldable:       ['reduce']
+  foldable:       ['reduce'],
+  transformer:    ['lift']
 };
+
+var Identity = require('..').Identity;
 
 function correctInterface(type) {
   return function(obj) {
@@ -89,5 +92,24 @@ module.exports = {
 
   foldable: {
     iface: correctInterface('foldable')
+  },
+
+  transformer: {
+    iface: function(T) {
+      return correctInterface('transformer')(T(Identity)) &&
+        correctInterface('monad')(T(Identity)(identity));
+    },
+    id: function(transformer) {
+      var T = transformer(Identity);
+      return T.lift(Identity.of(1)).equals(T.of(1));
+    },
+    associative: function(transformer) {
+      var T = transformer(Identity);
+      var m = Identity(1);
+      var f = function (x) { return Identity(x * x); };
+      return T.lift(m.chain(f)).equals(
+        T.lift(m).chain(function(x) { return T.lift(f(x)); })
+      );
+    }
   }
 };


### PR DESCRIPTION
Not sure if there is interest in going down the transformer path or not, but I ended up with this after wanting a Reader/Future combo.

An example:
```js
var Reader = require('./src/Reader'),
    Future = require('./src/Future'),
    ReaderTFuture = Reader.T(Future);

var log = console.log.bind(console);

var delay = d => Future((_, done) => setTimeout(done, d));

var delayedText = ReaderTFuture.ask.chain(env => 
  ReaderTFuture.lift(delay(env.delay).map(() => env.text))
);

delayedText.run({ delay: 1000, text: 'Hello!' }).fork(log, log);
```

If desirable, we could also implement `Reader` via `Reader.T(Identity)`.

I'm not sure how useful this is in the JS space, so I would appreciate comments by anyone who has experience with using `ReaderT`s in general.