### PR TITLE
Adds Fn type

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,5 +7,6 @@ module.exports = {
     lift3: require('./src/lift3'),
     Maybe: require('./src/Maybe'),
     Tuple: require('./src/Tuple'),
-    Reader: require('./src/Reader')
+    Reader: require('./src/Reader'),
+    Fn: require('./src/Fn')
 };

--- a/src/Fn.js
+++ b/src/Fn.js
@@ -1,0 +1,79 @@
+var R = require('ramda');
+
+function genFn(f, boundArgs, self) {
+  function _Fn() {
+    var args = boundArgs.concat(Array.prototype.slice.call(arguments, 0));
+    if (args.length >= f.length) {
+      return f.apply(self || this, args);
+    } else {
+      return genFn(f, args, self || this);
+    }
+  }
+
+  var properties = R.merge(Fn.prototype, {
+    '@@Fn/length': f['@@Fn/length'] || f.length,
+    '@@Fn/name':   f['@@Fn/name'] || f.name || '?',
+    '@@Fn/args':   boundArgs
+  });
+
+  return R.reduce(function(_Fn, prop) {
+    _Fn[prop[0]] = prop[1];
+    return _Fn;
+  }, _Fn, R.toPairs(properties));
+}
+
+function Fn(f) {
+  return genFn(f, []);
+}
+
+Fn.prototype.constructor = Fn;
+
+// Semigroup
+Fn.prototype.concat = Fn(function (g, x) {
+  return this(x).concat(g(x));
+});
+
+// Monoid
+Fn.prototype.empty = Fn.empty = Fn(function (x) {
+  return x.empty();
+});
+
+// Functor
+Fn.prototype.map = Fn(function (g, x) {
+  return g(this(x));
+});
+
+// Monad
+Fn.prototype.chain = Fn(function (g, x) {
+  return g(this(x))(x);
+});
+
+// Applicative
+Fn.prototype.of = Fn.of = Fn(function (x, _) {
+  // jshint unused:false
+  return x;
+});
+
+// Apply
+Fn.prototype.ap = Fn(function (g, x) {
+  return this(x)(g(x));
+});
+
+// Profunctor
+Fn.prototype.dimap = Fn(function (fore, hind, x) {
+  return hind(this(fore(x)));
+});
+
+// Semigroupoid
+Fn.prototype.compose = Fn(function (g, x) {
+  return this(g(x));
+});
+
+Fn.prototype.toString = Fn(function () {
+  var remaining = this['@@Fn/length'] - this['@@Fn/args'].length;
+  var placeholders = Array.apply(null, Array(remaining)).map(function () { return '_'; });
+  var argsString = this['@@Fn/args'].concat(placeholders).join(', ');
+  return 'Fn[' + this['@@Fn/name'] + '](' + argsString + ')';
+});
+
+module.exports = Fn;

--- a/test/fn.test.js
+++ b/test/fn.test.js
@@ -1,0 +1,210 @@
+var assert = require('assert');
+
+var Fn = require('..').Fn;
+
+describe('Fn', function () {
+
+  var id = Fn(function (x) {
+    return x;
+  });
+  var add = Fn(function (a, b) {
+    return a + b;
+  });
+  var mul = Fn(function (a, b) {
+    return a * b;
+  });
+  var composeFn = Fn(function (f, g, x) {
+    return f(g(x));
+  });
+  var apply = Fn(function (x, f) {
+    return f(x);
+  });
+
+  it('produces a curried function', function () {
+    var incr = add(1);
+    assert.strictEqual(incr(10), 11);
+  });
+
+  describe('is a Monoid', function () {
+    function Mul(v) {
+      this.val = v;
+    }
+
+    Mul.prototype.empty = Mul.empty = function empty() {
+      return new Mul(1);
+    };
+    Mul.prototype.concat = function concat(b) {
+      return new Mul(this.val * b.val);
+    };
+    Mul.prototype.equals = function equals(b) {
+      return b instanceof Mul && this.val === b.val;
+    };
+
+    var m = new Mul(42);
+    var addMul1 = Fn(function add1(x) {
+      return new Mul(x.val + 1);
+    });
+    var mulMul10 = Fn(function mul10(x) {
+      return new Mul(x.val * 10);
+    });
+
+    it('satisfies left neutral', function () {
+      assert.strictEqual(Fn.empty().concat(id)(m).equals(m), true);
+    });
+
+    it('satisfies right neutral', function () {
+      assert.strictEqual(id.concat(Fn.empty())(m).equals(m), true);
+    });
+
+    it('satisfies associativity', function () {
+      var monoidLaw3L = id.concat(addMul1.concat(mulMul10));
+      var monoidLaw3R = id.concat(addMul1).concat(mulMul10);
+      assert.strictEqual(monoidLaw3L(m).equals(monoidLaw3R(m)), true);
+    });
+  });
+
+  describe('is a Functor', function () {
+    it('satisfies identity', function () {
+      var x = 42, y = 1;
+      assert.strictEqual(add(x).map(id)(y), id(add(x))(y));
+    });
+
+    it('satisfies composition', function () {
+      var x = 42, y = 2, z = 1;
+      assert.strictEqual(
+        id.map(add(x).compose(mul(y)))(z),
+        id.map(mul(y)).map(add(x))(z)
+      );
+    });
+  });
+
+  describe('is an Applicative', function () {
+    it('satisfies identity', function () {
+      var x = 42, y = 1;
+      assert.strictEqual(
+        Fn.of(function (z) {
+          return z;
+        }).ap(add(x))(y),
+        add(x)(y)
+      );
+    });
+
+    it('satisfies composition', function () {
+      var x = 42;
+      assert.strictEqual(
+        Fn.of(composeFn).ap(add).ap(mul).ap(id)(x),
+        add.ap(mul.ap(id))(x)
+      );
+    });
+
+    it('satisifies homomorphism', function () {
+      var x = 1, y = 42, z = 10;
+      assert.strictEqual(
+        Fn.of(add(x)).ap(Fn.of(y))(z),
+        Fn.of(add(x, y))(z)
+      );
+    });
+
+    it('satisfies interchange', function () {
+      var x = 42, y = 1;
+      assert.strictEqual(
+        add.ap(Fn.of(x))(y),
+        Fn.of(apply(x)).ap(add)(y)
+      );
+    });
+
+    it('satisfies functor', function () {
+      var x = 42, f = function (a) {
+        return a * a;
+      };
+      assert.strictEqual(id.map(f)(x), Fn.of(f).ap(id)(x));
+    });
+  });
+
+  describe('is a Monad', function () {
+    it('satisfies left identity', function () {
+      var x = 42, y = 1;
+      assert.strictEqual(Fn.of(x).chain(add)(y), add(x)(y));
+    });
+    it('satisfies right identity', function () {
+      var x = 42;
+      assert.strictEqual(id.chain(Fn.of)(x), id(x));
+    });
+    it('satisfies associativity', function () {
+      var x = 42;
+      assert.strictEqual(
+        id.chain(add).chain(mul)(x),
+        id.chain(function (a) {
+          return add(a).chain(mul);
+        })(x)
+      );
+    });
+  });
+
+  describe('is a Profunctor', function () {
+    it('satisfies identity', function () {
+      var x = 42, y = 1;
+      assert.strictEqual(
+        add(x).dimap(id, id)(y),
+        id(add(x))(y)
+      );
+    });
+
+    it('satisfies composition', function () {
+      var h = mul(2);
+      var h_ = add(42);
+      var f = add(2);
+      var f_ = mul(42);
+      var x = 10;
+      assert.strictEqual(
+        id.dimap(h_.compose(h), f.compose(f_))(x),
+        id.dimap(h_, f_).dimap(h, f)(x)
+      );
+    });
+  });
+
+  describe('is a Semigroupoid', function () {
+    it('satisfies left identity', function () {
+      var x = 42, f = add(10);
+      assert.strictEqual(id.compose(f)(x), f(x));
+    });
+
+    it('satisfies right identity', function () {
+      var x = 42, f = add(10);
+      assert.strictEqual(f.compose(id)(x), f(x));
+    });
+
+    it('satisfies composition', function () {
+      var f = add(10), g = mul(2), h = add(4), x = 42;
+      assert.strictEqual(
+        f.compose(g).compose(h)(x),
+        f.compose(g.compose(h))(x)
+      );
+    });
+  });
+
+  describe('#toString', function () {
+    it('returns the string representation of a named function', function () {
+      assert.strictEqual(Fn(function undef() {}).toString(), 'Fn[undef]()'); });
+
+    it('returns the string representation of a anonymous function', function () {
+      assert.strictEqual(Fn(function() {}).toString(), 'Fn[?]()');
+    });
+
+    it('returns the string representation of a named function with args', function () {
+      assert.strictEqual(Fn(function add(a, b) { return a + b; }).toString(), 'Fn[add](_, _)');
+    });
+
+    it('returns the string representation of an anonymous function with args', function () {
+      assert.strictEqual(Fn(function(a, b) { return a + b; }).toString(), 'Fn[?](_, _)');
+    });
+
+    it('returns the string representation of a partially applied named function', function () {
+      assert.strictEqual(Fn(function add(a, b) { return a + b; })(1).toString(), 'Fn[add](1, _)');
+    });
+
+    it('returns the string representation of a partially applied anonymous function', function () {
+      assert.strictEqual(Fn(function(a, b) { return a + b; })(1).toString(), 'Fn[?](1, _)');
+    });
+  });
+});


### PR DESCRIPTION
I don't quite know where this sits on a scale from zero to absurd, but it's effectively a newtype wrapper for functions, providing implementations for a number of the fantasy land specs without polluting the global `Function.prototype`.

The result of calling `Fn` is a curried function, with a bunch of methods attached:
```js
var add = Fn((a, b) => a + b);
var mul = Fn((a, b) => a * b);

add(1, 2); // 3
var incr = add(1);
incr(2); // 3

add(2).compose(mul(4))(10); // 42
add(2).map(mul(4))(10); // 48

Fn(R.prepend).ap(R.of)('x'); // [ 'x', 'x' ]

mul(2).chain(a =>
  add(10).chain(b =>
    Fn.of(a + b)))(3) // 19
```

It also adds some pretty printing, which *should* survive currying and also include any partially applied arguments:
```js
var add = function Fn(add(a, b) { return a + b; });
add.toString(); // Fn[add](_, _)
add(1).toString(); // Fn[add](1, _)

var anonId = Fn(x => x);
Fn(anonId).toString(); // Fn(_)
```

If anyone is familiar with the various class implementations for function types, please provide some feedback as this was a bit of a learning exercise for me. In particular, some confirmation that the laws are in fact tested correctly would be most welcome. Unfortunately the existing law assertions in `tests/types.js` couldn't be used because they require the type to implement `equals`, which can't easily be defined for functions. I do however have another change I can submit for allowing a custom equality function to be passed in to the type assertions, which would resolve this.