### PR TITLE
Catch errors thrown in the fork function

### DIFF
--- a/src/Future.js
+++ b/src/Future.js
@@ -5,8 +5,16 @@ function Future(f) {
   if (!(this instanceof Future)) {
     return new Future(f);
   }
-  this.fork = f;
+  this._fork = f;
 }
+
+Future.prototype.fork = function(reject, resolve) {
+  try {
+    this._fork(reject, resolve);
+  } catch(e) {
+    reject(e);
+  }
+};
 
 // functor
 Future.prototype.map = function(f) {
@@ -94,7 +102,7 @@ Future.reject = function(val) {
 };
 
 Future.prototype.toString = function() {
-  return 'Future(' + R.toString(this.fork) + ')';
+  return 'Future(' + R.toString(this._fork) + ')';
 };
 
 module.exports = Future;

--- a/test/future.test.js
+++ b/test/future.test.js
@@ -201,5 +201,42 @@ describe('Future', function() {
 
   });
 
+  describe('#fork', function() {
+
+    var result;
+    var futureOne = Future.of(1);
+    var throwError = function() {
+      throw new Error('Some error message');
+    };
+    var setErrorResult = function(e) {
+      result = e.message;
+    };
+
+    beforeEach(function() {
+      result = null;
+    });
+
+    it('creates a rejected future if the resolve function throws an error', function() {
+      futureOne.fork(setErrorResult, throwError);
+      assert.equal('Some error message', result);
+    });
+
+    it('rejects the future if an error is thrown in a map function', function() {
+      futureOne.map(throwError).fork(setErrorResult);
+      assert.equal('Some error message', result);
+    });
+
+    it('rejects the future if an error is thrown in a chain function', function() {
+      futureOne.chain(throwError).fork(setErrorResult);
+      assert.equal('Some error message', result);
+    });
+
+    it('rejects the future if an error is thrown in a ap function', function() {
+      Future.of(throwError).ap(futureOne).fork(setErrorResult);
+      assert.equal('Some error message', result);
+    });
+
+  });
+
 });
 


### PR DESCRIPTION
When futures are forked, if the fork function throws a synchronous error
it is now caught and passed to the reject function.