### PR TITLE
Removes `equals` from `IO` and `Reader`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "ramda": "^0.15.0"
+    "ramda": ">=0.15.0 <0.18.0"
   },
   "devDependencies": {
     "jscs": "1.13.x",

--- a/src/IO.js
+++ b/src/IO.js
@@ -15,7 +15,8 @@ function IO(fn) {
 IO.prototype.chain = function(f) {
   var io = this;
   return new IO(function() {
-    return f(io.fn()).fn();
+    var next = f(io.fn.apply(io, arguments));
+    return next.fn.apply(next, arguments);
   });
 };
 
@@ -45,13 +46,6 @@ IO.prototype.of = function(x) {
 };
 
 IO.of = IO.prototype.of;
-
-// this is really only to accommodate testing ....
-IO.prototype.equals = function(that) {
-  return this === that ||
-    this.fn === that.fn ||
-    R.equals(IO.runIO(this), IO.runIO(that));
-};
 
 IO.prototype.toString = function() {
   return 'IO(' + R.toString(this.fn) + ')';

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -40,12 +40,6 @@ Reader.of = Reader.prototype.of;
 
 Reader.ask = Reader(R.always);
 
-Reader.prototype.equals = function(that) {
-  return this === that ||
-  this.run === that.run ||
-  R.equals(Reader.run(this), Reader.run(that));
-};
-
 Reader.prototype.toString = function() {
   return 'Reader(' + R.toString(this.run) + ')';
 };

--- a/test/either.test.js
+++ b/test/either.test.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
-var types = require('./types');
+var equalsInvoker = require('./utils').equalsInvoker;
+var types = require('./types')(equalsInvoker);
 
 var Either = require('..').Either;
 

--- a/test/future.test.js
+++ b/test/future.test.js
@@ -1,6 +1,7 @@
 var R = require('ramda');
 var assert = require('assert');
-var types = require('./types');
+var equalsInvoker = require('./utils').equalsInvoker;
+var types = require('./types')(equalsInvoker);
 var Future = require('../src/Future');
 
 Future.prototype.equals = function(b) {

--- a/test/identity.test.js
+++ b/test/identity.test.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
-var types = require('./types');
+var equalsInvoker = require('./utils').equalsInvoker;
+var types = require('./types')(equalsInvoker);
 
 var Identity = require('..').Identity;
 

--- a/test/io.test.js
+++ b/test/io.test.js
@@ -1,5 +1,7 @@
 var assert = require('assert');
-var types = require('./types');
+var types = require('./types')(function(io1, io2) {
+  return io1.runIO('x') === io2.runIO('x');
+});
 
 var IO = require('..').IO;
 

--- a/test/maybe.test.js
+++ b/test/maybe.test.js
@@ -1,6 +1,7 @@
 var R = require('ramda');
 var assert = require('assert');
-var types = require('./types');
+var equalsInvoker = require('./utils').equalsInvoker;
+var types = require('./types')(equalsInvoker);
 var jsv = require('jsverify');
 
 var Maybe = require('..').Maybe;

--- a/test/tuple.test.js
+++ b/test/tuple.test.js
@@ -1,6 +1,7 @@
 var R = require('ramda');
 var assert = require('assert');
-var types = require('./types');
+var equalsInvoker = require('./utils').equalsInvoker;
+var types = require('./types')(equalsInvoker);
 var jsv = require('jsverify');
 
 var Tuple = require('..').Tuple;

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,5 @@
+var R = require('ramda');
+
+module.exports = {
+  equalsInvoker: R.invoker(1, 'equals')
+};


### PR DESCRIPTION
- `types.js` tests now accept a custom equality function to be passed in.
- Bumps ramda version to 0.17
- [fix] `IO.chain` has been updated to pass on `arguments`

Fixes #63