### PR TITLE
Adds sum and product types.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,5 +7,6 @@ module.exports = {
     lift3: require('./src/lift3'),
     Maybe: require('./src/Maybe'),
     Tuple: require('./src/Tuple'),
-    Reader: require('./src/Reader')
+    Reader: require('./src/Reader'),
+    Type: require('./src/Type')
 };

--- a/src/Type.js
+++ b/src/Type.js
@@ -1,0 +1,193 @@
+var R = require('ramda');
+
+module.exports = {
+  sum: sum,
+  product: productOf(null)
+};
+
+/**
+ * # Algebraic Data Types
+ *
+ * Algebraic data types are a way of modeling data, typically in two forms known
+ * as product types and sum types. Product types associate values with their
+ * fields (similar to a standard object in javascript), while sum types model a
+ * group of different types together as a single type.
+ *
+ * ## Product types
+ *
+ * Product types can be created by calling `product` with strings
+ * representing the fields to exist on each type.
+ *
+ * For example, the following will create a `Point` type with two
+ * fields (`x` and `y`):
+ * ```js
+ * var Point = Type.product('x', 'y');
+ * ```
+ *
+ * Instances are created by calling the type as a function:
+ * ```js
+ * var origin = Point(0, 0);
+ * origin instanceof Point // true
+ * ```
+ *
+ * Once an instance is created, its fields can be accessed via
+ * getter methods attached to the instance:
+ * ```js
+ * var originX = origin.x();
+ * ```
+ *
+ * Alternatively an instance can be unapplied, providing access to
+ * all its fields in one call:
+ * ```js
+ * origin.unapply(function(x, y) {
+ *   return x === 0 && y === 0;
+ * });
+ * ```
+ *
+ * Values of a product instance can also be modified, however because the
+ * instances are immutable this will cause a new instance to be returned with
+ * the modified value rather than mutating the previous instance.
+ * ```js
+ * var x1y0 = origin.x(1);
+ * x1y0.x(); // 1
+ *
+ * // note `origin` remains unmodified
+ * origin.x(); // 0
+ * ```
+ *
+ * When a type is created, lenses for each field are also available on the
+ * type constructor:
+ * ```js
+ * R.view(Point.x, point); // 0
+ * R.set(Point.y, point);  // Point(0, 1);
+ * ```
+ *
+ * ## Sum Types
+ *
+ * Sum types can be created by calling `sum` with an object that describes
+ * its constructors.
+ *
+ * For example will create a `List` type, with two constructors `Cons` and `Nil`:
+ * ```js
+ * var List = Type.sum({ Cons: ['head', 'tail'], Nil: [] });
+ * var Cons = List.Cons;
+ * var Nil = List.Nil;
+ * ```
+ *
+ * The constructors behave exactly the same as product type constructors:
+ * ```js
+ * var abc = Cons('a', Cons('b', Cons('c', Nil)));
+ * abc instanceof Cons; // true
+ * abc instanceof List; // true
+ *
+ * var c = abc.tail().tail().head();
+ * // or
+ * var c = R.view(R.compose(Cons.tail, Cons.tail, Cons.head), abc);
+ *
+ * abc.unapply(function(head, tail) {
+ *   return head + head + head;
+ * }); // "aaa"
+ * ```
+ *
+ * If a constructor is declared with no fields, a singleton instance
+ * of that constructor is returned instead:
+ * ```js
+ * Nil instanceof List; // true
+ * Nil.unapply(function() { return '?'; }); // '?'
+ * ```
+ *
+ * An instance can also be matched and dispatched against its type:
+ * ```js
+ * function headOrElse(other, list) {
+ *   return list.match({
+ *     Cons: function(head, tail) { return head; },
+ *     Nil: function() { return other; }
+ *   });
+ * }
+ * ```
+ */
+
+// Allows a given `proto` to be used as the base prototype of the product
+// instances -- this is used by `sum` to extend the generated sum type without
+// resorting to setting __proto__ or relying on Object.setPrototypeOf introduced
+// in ES6.
+function productOf(proto) {
+  // The actual function used to create a product type with the given set of field names.
+  return function() {
+    var field, i;
+    var fields = arguments;
+    var Constructor = R.curryN(fields.length, function () {
+      var vals = arguments;
+      return Object.create(Constructor.prototype, {
+        unapply: {
+          value: function unapply(f) {
+            return f.apply(this, vals);
+          }
+        }
+      });
+    });
+    Constructor.prototype = Object.create(proto);
+    Constructor.prototype.constructor = Constructor;
+    for (i = 0; i < fields.length; i++) {
+      field = fields[i];
+      Constructor[field] = productLens(i);
+      Constructor.prototype[field] = getterSetter(field);
+    }
+    return Constructor;
+  };
+}
+
+// The function used to create a sum type with the given constructor descriptor.
+function sum(constructors) {
+  var Type = function () {};
+
+  function buildProto(name) {
+    return Object.create(Type.prototype, {
+      match: {
+        value: function(cases) {
+          return this.unapply(cases[name]);
+        }
+      }
+    });
+  }
+
+  function buildConstructor(name, fields) {
+    var constructor = productOf(buildProto(name)).apply(null, fields);
+    constructor.prototype.constructor = constructor;
+    // Return a singleton instance for nullary constructors
+    return fields.length > 0 ? constructor : constructor();
+  }
+
+  for (var k in constructors) {
+    if (constructors.hasOwnProperty(k)) {
+      Type[k] = buildConstructor(k, constructors[k]);
+    }
+  }
+  return Type;
+}
+
+// Creates a lens with a focus on the `n`th field of a product instance.
+function productLens(n) {
+  return R.lens(
+    function(p) {
+      return p.unapply(R.nthArg(n));
+    },
+    function(x, p) {
+      return p.unapply(function() {
+        return p.constructor.apply(null, R.update(n, x, arguments));
+      });
+    }
+  );
+}
+
+// Returns a getter/setter function for the given field name.
+// If called with no arguments, the field's value will be returned, otherwise
+// a new instance will be returned with the field's value replaced with the
+// first argument.
+function getterSetter(field) {
+  return function() {
+    var lens = this.constructor[field];
+    return arguments.length > 0 ? R.set(lens, arguments[0], this)
+                                : R.view(lens, this);
+  };
+}

--- a/test/type.test.js
+++ b/test/type.test.js
@@ -1,0 +1,92 @@
+var R = require('ramda');
+var assert = require('assert');
+
+var Type = require('..').Type;
+
+describe('Type.product', function() {
+  var point = Type.product('x', 'y');
+  point.prototype.equals = function(p) {
+    return p instanceof point &&
+      this.x() === p.x() &&
+      this.y() === p.y();
+  };
+  var point_1_2 = point(1, 2);
+
+  it('creates a curried constructor', function() {
+    assert(point(1)(2).equals(point_1_2));
+  });
+
+  it('creates lenses for all properties', function() {
+    assert.strictEqual(R.view(point.x, point_1_2), 1);
+    assert.strictEqual(R.view(point.y, point_1_2), 2);
+    assert(R.set(point.x, 3, point_1_2).equals(point(3, 2)));
+    assert(R.set(point.y, 3, point_1_2).equals(point(1, 3)));
+  });
+
+  describe('instances', function() {
+    it('can be unapplied to access the properties', function() {
+      var xy = point_1_2.unapply(function(x, y) { return [x, y]; });
+      assert.strictEqual(xy[0], 1);
+      assert.strictEqual(xy[1], 2);
+    });
+
+    it('creates a getter/setter method for each declared property', function() {
+      assert.strictEqual(point_1_2.x(), 1);
+      assert.strictEqual(point_1_2.y(), 2);
+      assert(point_1_2.x(3).equals(point(3, 2)));
+      assert(point_1_2.y(3).equals(point(1, 3)));
+    });
+
+    it('returns a new instance when a setter is called', function() {
+      var point_0_2 = point_1_2.x(0);
+      assert(point_0_2.equals(point(0, 2)));
+      assert(point_1_2.equals(point(1, 2)));
+    });
+
+    it('is an instanceof its constructor', function() {
+      assert(point_1_2 instanceof point);
+    });
+  });
+});
+
+describe('Type.sum', function() {
+  it('creates a product constructor for each declared type', function() {
+    var Foo = Type.sum({ Bar: ['a', 'b'], Baz: ['c'] });
+    var bar = Foo.Bar(1, 2);
+    var baz = Foo.Baz(3);
+    var _1_2 = bar.unapply(function(a, b) { return [a, b]; });
+    var _3 = baz.unapply(function(c) { return c; });
+    assert.strictEqual(_1_2[0], 1);
+    assert.strictEqual(_1_2[1], 2);
+    assert.strictEqual(_3, 3);
+  });
+
+  it('creates a singleton instance for constructors with no properties', function() {
+    var Maybe = Type.sum({ Just: ['value'], Nothing: [] });
+    assert(Maybe.Nothing instanceof Maybe);
+    assert.strictEqual(Maybe.Nothing.unapply(function() { return 'foo'; }), 'foo');
+  });
+
+  describe('instances', function() {
+    it('can be matched against each type', function() {
+      var Either = Type.sum({ Left: ['value'], Right: ['value'] });
+      var left1 = Either.Left(1);
+      var right2 = Either.Right(2);
+      assert(left1.match({
+        Left: function(x) { return x === 1; },
+        Right: function() { return false; }
+      }));
+      assert(right2.match({
+        Left: function() { return false; },
+        Right: function(x) { return x === 2; }
+      }));
+    });
+
+    it('is an instance of its type', function() {
+      var Foo = Type.sum({ Bar: ['x'] });
+      assert(Foo.Bar(1) instanceof Foo.Bar);
+      assert(Foo.Bar(1) instanceof Foo);
+    });
+  });
+});
+


### PR DESCRIPTION
This changes adds support for creating sum and product ADTs. I'm not entirely sure this belongs in ramda-fantasy or not, but it does make declaring data types clean and consistent (at least in my opinion).

I've also got a separate branch with the existing types converted to using ADTs for those who are curious: https://github.com/scott-christopher/ramda-fantasy/blob/adt/src/Maybe.js (I wanted to keep this PR focussed on the ADT implementation itself, before discussing changing anything else).

I've added the comments from the code below that describes the general usage.

---
## Product types

Product types can be created by calling `product` with strings representing the fields to exist on each type.

For example, the following will create a `Point` type with two fields (`x` and `y`):

``` js
var Point = Type.product('x', 'y');
```

Instances are created by calling the type as a function:

``` js
var origin = Point(0, 0);
origin instanceof Point // true
```

Once an instance is created, its fields can be accessed via getter methods attached to the instance:

``` js
var originX = origin.x();
```

Alternatively an instance can be unapplied, providing access to all its fields in one call:

``` js
origin.unapply(function(x, y) {
  return x === 0 && y === 0;
});
```

Values of a product instance can also be modified, however because the instances are immutable this will cause a new instance to be returned with the modified value rather than mutating the previous instance.

``` js
var x1y0 = origin.x(1);
x1y0.x(); // 1

// note `origin` remains unmodified
origin.x(); // 0
```

When a type is created, lenses for each field are also available on the type constructor:

``` js
R.view(Point.x, point); // 0
R.set(Point.y, point);  // Point(0, 1);
```
## Sum Types

Sum types can be created by calling `sum` with an object that describes its constructors.

For example will create a `List` type, with two constructors `Cons` and `Nil`:

``` js
var List = Type.sum({ Cons: ['head', 'tail'], Nil: [] });
var Cons = List.Cons;
var Nil = List.Nil;
```

The constructors behave exactly the same as product type constructors:

``` js
var abc = Cons('a', Cons('b', Cons('c', Nil)));
abc instanceof Cons; // true
abc instanceof List; // true

var c = abc.tail().tail().head();
// or
var c = R.view(R.compose(Cons.tail, Cons.tail, Cons.head), abc);

abc.unapply(function(head, tail) {
  return head + head + head;
}); // "aaa"
```

If a constructor is declared with no fields, a singleton instance of that constructor is returned instead:

``` js
Nil instanceof List; // true
Nil.unapply(function() { return '?'; }); // '?'
```

An instance can also be matched and dispatched against its type:

``` js
function headOrElse(other, list) {
  return list.match({
    Cons: function(head, tail) { return head; },
    Nil: function() { return other; }
  });
}
```
