### PR TITLE
Various changes to Either

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "jscs": "1.13.x",
     "jshint": "~2.7.0",
-    "jsverify": "^0.5.1",
+    "jsverify": "^0.7.1",
     "mocha": "^2.1.0",
     "uglify-js": "2.4.x",
     "xyz": "0.5.x"

--- a/src/Either.js
+++ b/src/Either.js
@@ -78,7 +78,7 @@ function _Left(x) {
 }
 util.extend(_Left, Either);
 
-_Left.prototype.ap = function(that) { return that; };
+_Left.prototype.ap = util.returnThis;
 
 _Left.prototype.bimap = function(f) {
   return new _Left(f(this.value));

--- a/test/types.js
+++ b/test/types.js
@@ -7,6 +7,7 @@ var interfaces = {
   chain:          ['map', 'ap', 'chain'],
   monad:          ['map', 'ap', 'chain', 'of'],
   extend:         ['extend'],
+  comonad:        ['extend', 'extract'],
   foldable:       ['reduce'],
   transformer:    ['lift']
 };
@@ -98,7 +99,25 @@ module.exports = function(eq) {
     },
 
     extend: {
-      iface: correctInterface('extend')
+      iface: correctInterface('extend'),
+      associative: function(obj, f, g) {
+        return eq(
+          obj.extend(g).extend(f),
+          obj.extend(function(_obj) {
+            return f(_obj.extend(g));
+          })
+        );
+      }
+    },
+
+    comonad: {
+      iface: correctInterface('comonad'),
+      leftIdentity: function (obj) {
+        return eq(obj.extend(function(_obj) { return _obj.extract(); }), obj);
+      },
+      rightIdentity: function (obj, f) {
+        return eq(obj.extend(f).extract(), f(obj));
+      }
     },
 
     foldable: {


### PR DESCRIPTION
- Either::ap now returns `this` for `Left` (fixes #75)
- ~~Either::extract added~~
- ~~Either::extend no longer returns `this` for `Left` to satisfy `extract . extend f = f`~~
- Either tests refactored to use JSVerify
- Comonad laws added to test/types.js