### PR TITLE
Update ramda version range to include 0.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "ramda": ">=0.15.0 <0.18.0"
+    "ramda": ">=0.15.0 <=0.18.0"
   },
   "devDependencies": {
     "jscs": "1.13.x",


### PR DESCRIPTION
Test suite passes with 15, 16, 17 and 18