### PR TITLE
Improve Future try-catching

### DIFF
--- a/test/future.test.js
+++ b/test/future.test.js
@@ -212,6 +212,11 @@ describe('Future', function() {
     var setErrorResult = function(e) {
       result = e.message;
     };
+    var delayValue = function(delay, value) {
+      return new Future(function(reject, resolve) {
+        setTimeout(resolve, delay, value);
+      });
+    };
 
     beforeEach(function() {
       result = null;
@@ -235,6 +240,21 @@ describe('Future', function() {
     it('rejects the future if an error is thrown in a ap function', function() {
       Future.of(throwError).ap(futureOne).fork(setErrorResult);
       assert.equal('Some error message', result);
+    });
+
+    it('eventually rejects the future if an error is thrown in a chain function', function(done){
+      var throwEscapeError = function(){
+        throw new Error('This error should be caught');
+      };
+      delayValue(15, 1).chain(throwEscapeError).fork(
+        function(err){
+          assert.equal('This error should be caught', err.message);
+          done();
+        },
+        function(){
+          done(new Error('The future resolved'));
+        }
+      );
     });
 
   });


### PR DESCRIPTION
I noticed Ramda Future wraps `fork` in a *try-catch*. I'm assuming this was done with the intention to automatically catch errors from throwing user functions. In a purely functional world that wouldn't make sense, but I can appreciate the idea that this protects users of Future from the rigors of multi-paradigm.

However, I think that Futures should either *have* this behaviour (like `bluebird`), or not have it at all (like `data.task`), but Ramda Futures have it "*sometimes*", as demonstrated by the following code (also added as unit test), and I think this is quite confusing:

```js
//The error is caught and handled by handler:
Future.of(1).map(throws).fork(handler, noop);

//The error escapes and destroys everything you ever loved:
delayedFutureOf(1).map(throws).fork(handler, noop);
```
> Open debugger to see effects: http://goo.gl/crHJ5F

Another issue with the current implementation is that often, functions that we know are *pure* are also being wrapped in try-catch statements. This [probably](https://github.com/ramda/ramda-fantasy/pull/82) results in unnecessary performance loss.

I tried to solve both issues with the following changes:

* ~~Switched many internal "fork" calls to "_fork" calls to reduce needless try-catch wrapping of internal functions that were never going to throw.~~ (see [pull 82](https://github.com/ramda/ramda-fantasy/pull/82))
* Wrapped potentially throwing user functions in try-catch to ensure the error will end up in the rejection branch.

Another solution would be to never try-catch, which could be implemented by simply removing `Future#fork` and assigning it in the constructor.

> #### Disclaimer
> I haven't actually tested for performance gains or losses. :)