### PR TITLE
specify "@@type" property for each type

### DIFF
--- a/src/Either.js
+++ b/src/Either.js
@@ -16,6 +16,8 @@ function Either(left, right) {
   }
 }
 
+Either.prototype['@@type'] = 'ramda-fantasy/Either';
+
 Either.prototype.map = util.returnThis;
 
 Either.of = Either.prototype.of = function(value) {

--- a/src/Future.js
+++ b/src/Future.js
@@ -18,6 +18,8 @@ function Future(f) {
   this._fork = f;
 }
 
+Future.prototype['@@type'] = 'ramda-fantasy/Future';
+
 Future.prototype.fork = function(reject, resolve) {
   this._fork(reject, jail(reject, resolve));
 };

--- a/src/IO.js
+++ b/src/IO.js
@@ -11,6 +11,8 @@ function IO(fn) {
   this.fn = fn;
 }
 
+IO.prototype['@@type'] = 'ramda-fantasy/IO';
+
 // `f` must return an IO
 IO.prototype.chain = function(f) {
   var io = this;

--- a/src/Identity.js
+++ b/src/Identity.js
@@ -20,6 +20,8 @@ function Identity(x) {
   this.value = x;
 }
 
+Identity.prototype['@@type'] = 'ramda-fantasy/Identity';
+
 /**
  * Applicative specification. Creates a new `Identity[a]` holding the value `a`.
  * @param {*} a Value of any type

--- a/src/Maybe.js
+++ b/src/Maybe.js
@@ -6,6 +6,8 @@ function Maybe(x) {
   return x == null ? _nothing : Maybe.Just(x);
 }
 
+Maybe.prototype['@@type'] = 'ramda-fantasy/Maybe';
+
 function Just(x) {
   this.value = x;
 }

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -12,6 +12,8 @@ Reader.run = function(reader) {
   return reader.run.apply(reader, [].slice.call(arguments, 1));
 };
 
+Reader.prototype['@@type'] = 'ramda-fantasy/Reader';
+
 Reader.prototype.chain = function(f) {
   var reader = this;
   return new Reader(function(r) {

--- a/src/Tuple.js
+++ b/src/Tuple.js
@@ -36,6 +36,8 @@ Tuple.snd = function(x) {
   return x[1];
 };
 
+_Tuple.prototype['@@type'] = 'ramda-fantasy/Tuple';
+
 // semigroup
 _Tuple.prototype.concat = function(x) {
   ensureConcat([this[0], this[1]]);

--- a/test/either.test.js
+++ b/test/either.test.js
@@ -110,6 +110,15 @@ describe('Either', function() {
     });
   });
 
+  describe('#@@type', function() {
+
+    it('is "ramda-fantasy/Either"', function() {
+      assert.strictEqual(Either.Left(null)['@@type'], 'ramda-fantasy/Either');
+      assert.strictEqual(Either.Right(null)['@@type'], 'ramda-fantasy/Either');
+    });
+
+  });
+
   describe('#toString', function() {
 
     it('returns the string representation of a Left', function() {

--- a/test/future.test.js
+++ b/test/future.test.js
@@ -191,6 +191,17 @@ describe('Future', function() {
 
   });
 
+  describe('#@@type', function() {
+
+    it('is "ramda-fantasy/Future"', function() {
+      assert.strictEqual(
+        Future(function(reject, resolve) { void resolve; })['@@type'],
+        'ramda-fantasy/Future'
+      );
+    });
+
+  });
+
   describe('#toString', function() {
 
     it('returns the string representation of a Future', function() {

--- a/test/identity.test.js
+++ b/test/identity.test.js
@@ -62,6 +62,14 @@ describe('Identity', function() {
     assert.equal(true, mTest.iface(m));
   });
 
+  describe('#@@type', function() {
+
+    it('is "ramda-fantasy/Identity"', function() {
+      assert.strictEqual(Identity(null)['@@type'], 'ramda-fantasy/Identity');
+    });
+
+  });
+
   describe('#toString', function() {
 
     it('returns the string representation of an Identity', function() {

--- a/test/io.test.js
+++ b/test/io.test.js
@@ -90,6 +90,14 @@ describe('IO', function() {
     assert.equal(true, mTest.iface(i1));
   });
 
+  describe('#@@type', function() {
+
+    it('is "ramda-fantasy/IO"', function() {
+      assert.strictEqual(IO(function() {})['@@type'], 'ramda-fantasy/IO');
+    });
+
+  });
+
   describe('#toString', function() {
 
     it('returns the string representation of an IO', function() {

--- a/test/maybe.test.js
+++ b/test/maybe.test.js
@@ -129,6 +129,15 @@ describe('Maybe usage', function() {
 
   });
 
+  describe('#@@type', function() {
+
+    it('is "ramda-fantasy/Maybe"', function() {
+      assert.strictEqual(Maybe.Just(null)['@@type'], 'ramda-fantasy/Maybe');
+      assert.strictEqual(Maybe.Nothing()['@@type'], 'ramda-fantasy/Maybe');
+    });
+
+  });
+
   describe('#toString', function() {
 
     it('returns the string representation of a Just', function() {

--- a/test/reader.test.js
+++ b/test/reader.test.js
@@ -91,6 +91,15 @@ describe('Reader properties', function() {
     });
   });
 
+  describe('#@@type', function() {
+
+    it('is "ramda-fantasy/Reader"', function() {
+      assert.strictEqual(Reader(function(x) { void x; })['@@type'],
+                         'ramda-fantasy/Reader');
+    });
+
+  });
+
   describe('#toString', function() {
 
     it('returns the string representation of a Reader', function() {

--- a/test/tuple.test.js
+++ b/test/tuple.test.js
@@ -157,6 +157,14 @@ describe('Tuple usage', function() {
     });
   });
 
+  describe('#@@type', function() {
+
+    it('is "ramda-fantasy/Tuple"', function() {
+      assert.strictEqual(Tuple(null, null)['@@type'], 'ramda-fantasy/Tuple');
+    });
+
+  });
+
   describe('#toString', function() {
 
     it('returns the string representation of a Tuple', function() {


### PR DESCRIPTION
This provides compatibility with `S.type`, added in plaid/sanctuary#105:

> #### `type :: a -> String`
>
> Takes a value, `x`, of any type and returns its type identifier. If `x` has a `'@@type'` property whose value is a string, `x['@@type']` is the type identifier. Otherwise, the type identifier is the result of applying [`R.type`][1] to `x`.
>
> `'@@type'` properties should use the form `'<package-name>/<type-name>'`, where `<package-name>` is the name of the npm package in which the type is defined.
>
> ```javascript
> > S.type(S.Just(42))
> 'sanctuary/Maybe'
>
> > S.type([1, 2, 3])
> 'Array'
> ```


[1]: http://ramdajs.com/docs/#type
