### PR TITLE
Reduce on unnecessary try-catch wrapping in Futures

### DIFF
--- a/src/Future.js
+++ b/src/Future.js
@@ -41,12 +41,12 @@ Future.prototype.ap = function(m) {
       }
     });
 
-    self.fork(doReject, function(fn) {
+    self._fork(doReject, function(fn) {
       applyFn = fn;
       resolveIfDone();
     });
 
-    m.fork(doReject, function(v) {
+    m._fork(doReject, function(v) {
       val = v;
       resolveIfDone();
     });
@@ -70,9 +70,9 @@ Future.prototype.of = Future.of;
 //:: Future a, b => (b -> Future c) -> Future c
 Future.prototype.chain = function(f) {  // Sorella's:
   return new Future(function(reject, resolve) {
-    return this.fork(
+    return this._fork(
       function(a) { return reject(a); },
-      jail(reject, function(b) { return f(b).fork(reject, resolve); })
+      jail(reject, function(b) { return f(b)._fork(reject, resolve); })
     );
   }.bind(this));
 };
@@ -82,8 +82,8 @@ Future.prototype.chain = function(f) {  // Sorella's:
 //:: Future a, b => (a -> Future c) -> Future c
 Future.prototype.chainReject = function(f) {
   return new Future(function(reject, resolve) {
-    return this.fork(
-      jail(reject, function(a) { return f(a).fork(reject, resolve); }),
+    return this._fork(
+      jail(reject, function(a) { return f(a)._fork(reject, resolve); }),
       function(b) { return resolve(b); }
     );
   }.bind(this));
@@ -96,7 +96,7 @@ Future.prototype.chainReject = function(f) {
 Future.prototype.bimap = function(errFn, successFn) {
   var self = this;
   return new Future(function(reject, resolve) {
-    self.fork(
+    self._fork(
       jail(reject, function(err) { reject(errFn(err)); }),
       jail(reject, function(val) { resolve(successFn(val)); })
     );
@@ -133,7 +133,7 @@ Future.cache = function(f) {
 
   function doResolve(reject, resolve) {
     status = 'PENDING';
-    return f.fork(
+    return f._fork(
       handleCompletion('REJECTED', reject),
       handleCompletion('RESOLVED', resolve)
     );


### PR DESCRIPTION
Switched many internal `fork` calls to `_fork` calls to reduce needless try-catch wrapping of internal functions that were never going to throw. Taken from [pull 79](https://github.com/ramda/ramda-fantasy/pull/79) where it was originally introduced.

The reason behind this change is that *try-catch-wrapping* [might cost some performance](https://jsperf.com/try-catch/7). I haven't actually tested this for performance gains, but I'd imagine that all that try-catch wrapping when using Future-heavy code might add up.