### PR TITLE
Add Future#concat()

### DIFF
--- a/src/Future.js
+++ b/src/Future.js
@@ -103,6 +103,31 @@ Future.prototype.bimap = function(errFn, successFn) {
   });
 };
 
+// semigroup
+// concat
+// Select the earlier of two Futures, effectively creating a race between them
+//:: Future a, b => Future a, b -> Future a, b
+
+Future.prototype.concat = function(m2) {
+  var m1 = this;
+
+  return new Future(function(reject, resolve){
+    var settled = false;
+
+    var once = function(f){
+      return function(a){
+        if(!settled){
+          settled = true;
+          f(a);
+        }
+      };
+    };
+
+    m1._fork(once(reject), once(resolve));
+    m2._fork(once(reject), once(resolve));
+  });
+};
+
 Future.reject = function(val) {
   return new Future(function(reject) {
     reject(val);


### PR DESCRIPTION
**Includes a failing unit test for discussion**

Hello again,

I've been working a tremendous amount with Futures of late. I've always liked Promises since their earliest introduction. Futures to me are the next step. They have a predictable API which is very easy to abstract over and therefore they integrate very well with stuff like Ramda.

However, despite being able to express all manner of async behaviour using just `chain` for sequences and `ap` for parrallelism, I find myself really missing a native, chainable way to do races. This is where `concat` comes in, which was heavily inspired by [its implementation in `data.task`](https://github.com/folktale/data.task/blob/master/lib/task.js#L137-L175).

Sorella commented it to be a Semigroup, as is also indicated by my passing *is a Semigroup* -test. Yet I've never really trusted it to always behave this way under race conditions, so I decided to write another test: *associativity is not broken by race-conditions*, which turned out to fail.

After some days of this branch collecting dust, I still decided to make a PR just to share my findings and maybe someone might yet point out that I'm wrong somehow and Sorella was right about her assessment of this implementation being a proper Semigroup. That's what I'm secretly hoping for, because it'd be really nice to get Semigroup and async races in Futures.

If, however, we collectively reach the conclusion that Future being Semigroup is in fact impossible, I'll gladly back down and implement this function as a helper in my code base somewhere.