### PR TITLE
Fix test semantics of reject for Future#ap

### DIFF
--- a/test/future.test.js
+++ b/test/future.test.js
@@ -118,8 +118,6 @@ describe('Future', function() {
       };
     }
 
-    function noop() {}
-
     it('applies its function to the passed in future', function() {
       var f1 = Future.of(add(1));
       var result = f1.ap(Future.of(2));
@@ -130,19 +128,19 @@ describe('Future', function() {
       this.timeout(25);
       var f1 = delayValue(15, 1);
       var f2 = delayValue(15, 2);
-      f1.map(add).ap(f2).fork(noop, assertCbVal(done, 3));
+      f1.map(add).ap(f2).fork(assert.fail, assertCbVal(done, 3));
     });
 
     it('can handle itself being resolved first', function(done) {
       var f1 = delayValue(1, 1);
       var f2 = delayValue(15, 2);
-      f1.map(add).ap(f2).fork(noop, assertCbVal(done, 3));
+      f1.map(add).ap(f2).fork(assert.fail, assertCbVal(done, 3));
     });
 
     it('can handle the input future being resolved first', function(done) {
       var f1 = delayValue(15, 1);
       var f2 = delayValue(1, 2);
-      f1.map(add).ap(f2).fork(noop, assertCbVal(done, 3));
+      f1.map(add).ap(f2).fork(assert.fail, assertCbVal(done, 3));
     });
 
     it('is rejected with the first error to occur - case 1', function(done) {


### PR DESCRIPTION
Replace noops with the more correct `assert.fail` to ensure test failure
in the event that the reject callback is run.

See #85 for discussion.