### PR TITLE
integrate sanctuary-def

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "test": "mocha"
   },
   "dependencies": {
-    "ramda": ">=0.15.0 <=0.19.0"
+    "ramda": ">=0.15.0 <=0.19.0",
+    "sanctuary-def": "0.1.x"
   },
   "devDependencies": {
     "jscs": "1.13.x",

--- a/test/either.test.js
+++ b/test/either.test.js
@@ -30,7 +30,9 @@ describe('Either', function() {
 
   it('is an Apply', function() {
     var aTest = types.apply;
-    jsv.assert(jsv.forall(eFnArb, eFnArb, eNatArb, aTest.compose));
+    var rNatArb = rightArb(jsv.nat);
+    var rFnArb = rightArb(jsv.fn(jsv.nat));
+    jsv.assert(jsv.forall(rFnArb, rFnArb, rNatArb, aTest.compose));
     jsv.assert(jsv.forall(eNatArb, aTest.iface));
   });
 


### PR DESCRIPTION
See #89

Advantages:

  - :white_check_mark: centralized, consistent approach to type checking
  - :white_check_mark: currying (without `R.curry`)
  - :white_check_mark: no "abstract bases classes"; no inheritance
  - :white_check_mark: no unreliable `instanceof` checks (if #81 is accepted)
  - :white_check_mark: increased implementation overlap with Sanctuary
  - :white_check_mark: straightforward [Transcribe][1] integration if desired

Disadvantages:

  - :x: additional dependency

This pull request currently only updates __src/Either.js__, to provide something concrete to discuss. If the rest of the team is on board I'll update the other files similarly.


[1]: https://github.com/plaid/transcribe
