### PR TITLE
Removes equals from ReaderT

### DIFF
--- a/src/Reader.js
+++ b/src/Reader.js
@@ -85,12 +85,6 @@ Reader.T = function(M) {
     });
   };
 
-  ReaderT.prototype.equals = function(that) {
-    return this === that ||
-      this.run === that.run ||
-      R.equals(this.run().get(), that.run().get());
-  };
-
   ReaderT.prototype.toString = function() {
     return 'ReaderT[' + M.name + '](' + R.toString(this.run) + ')';
   };


### PR DESCRIPTION
Following on from #93, `equals` doesn't make sense in the context of a `Reader`/`ReaderT`.