### PR TITLE
Tree-shake ramda by cherry-picking requires

### DIFF
--- a/src/Either.js
+++ b/src/Either.js
@@ -1,4 +1,5 @@
-var R = require('ramda');
+var curry = require('ramda/src/curry');
+var toString = require('ramda/src/toString');
 
 var util = require('./internal/util');
 
@@ -27,7 +28,7 @@ Either.prototype.chain = util.returnThis; // throw?
 
 Either.equals = Either.prototype.equals = util.getEquals(Either);
 
-Either.either = R.curry(function either(leftFn, rightFn, e) {
+Either.either = curry(function either(leftFn, rightFn, e) {
   if (e instanceof _Left) {
     return leftFn(e.value);
   } else if (e instanceof _Right) {
@@ -76,7 +77,7 @@ _Right.prototype.extend = function(f) {
 };
 
 _Right.prototype.toString = function() {
-  return 'Either.Right(' + R.toString(this.value) + ')';
+  return 'Either.Right(' + toString(this.value) + ')';
 };
 
 Either.Right = function(value) {
@@ -102,7 +103,7 @@ _Left.prototype.bimap = function(f) {
 _Left.prototype.extend = util.returnThis;
 
 _Left.prototype.toString = function() {
-  return 'Either.Left(' + R.toString(this.value) + ')';
+  return 'Either.Left(' + toString(this.value) + ')';
 };
 
 Either.Left = function(value) {

--- a/src/Future.js
+++ b/src/Future.js
@@ -1,4 +1,7 @@
-var R = require('ramda');
+var curry = require('ramda/src/curry');
+var forEach = require('ramda/src/forEach');
+var once = require('ramda/src/once');
+var toString = require('ramda/src/toString');
 
 function jail(handler, f){
   return function(a){
@@ -33,7 +36,7 @@ Future.prototype.ap = function(m) {
 
   return new Future(function(rej, res) {
     var applyFn, val;
-    var doReject = R.once(rej);
+    var doReject = once(rej);
 
     var resolveIfDone = jail(doReject, function() {
       if (applyFn != null && val != null) {
@@ -110,7 +113,7 @@ Future.reject = function(val) {
 };
 
 Future.prototype.toString = function() {
-  return 'Future(' + R.toString(this._fork) + ')';
+  return 'Future(' + toString(this._fork) + ')';
 };
 
 Future.cache = function(f) {
@@ -118,11 +121,11 @@ Future.cache = function(f) {
   var listeners = [];
   var cachedValue;
 
-  var handleCompletion = R.curry(function(newStatus, cb, val) {
+  var handleCompletion = curry(function(newStatus, cb, val) {
     status = newStatus;
     cachedValue = val;
     cb(val);
-    R.forEach(function(listener) {
+    forEach(function(listener) {
       listener[status](cachedValue);
     }, listeners);
   });

--- a/src/IO.js
+++ b/src/IO.js
@@ -1,8 +1,7 @@
-var R = require('ramda');
+var compose = require('ramda/src/compose');
+var toString = require('ramda/src/toString');
 
 module.exports = IO;
-
-var compose = R.compose;
 
 function IO(fn) {
   if (!(this instanceof IO)) {
@@ -48,5 +47,5 @@ IO.prototype.of = function(x) {
 IO.of = IO.prototype.of;
 
 IO.prototype.toString = function() {
-  return 'IO(' + R.toString(this.fn) + ')';
+  return 'IO(' + toString(this.fn) + ')';
 };

--- a/src/Identity.js
+++ b/src/Identity.js
@@ -1,4 +1,4 @@
-var R = require('ramda');
+var toString = require('ramda/src/toString');
 
 var util = require('./internal/util');
 
@@ -80,7 +80,7 @@ Identity.prototype.get = function() {
 Identity.prototype.equals = util.getEquals(Identity);
 
 Identity.prototype.toString = function() {
-  return 'Identity(' + R.toString(this.value) + ')';
+  return 'Identity(' + toString(this.value) + ')';
 };
 
 module.exports = Identity;

--- a/src/Maybe.js
+++ b/src/Maybe.js
@@ -1,4 +1,5 @@
-var R = require('ramda');
+var curry = require('ramda/src/curry');
+var toString = require('ramda/src/toString');
 
 var util = require('./internal/util.js');
 
@@ -42,7 +43,7 @@ Maybe.isNothing = function(x) {
   return x.isNothing;
 };
 
-Maybe.maybe = R.curry(function(nothingVal, justFn, m) {
+Maybe.maybe = curry(function(nothingVal, justFn, m) {
   return m.reduce(function(_, x) {
     return justFn(x);
   }, nothingVal);
@@ -118,7 +119,7 @@ _Nothing.prototype.reduce = function(f, x) {
 };
 
 _Just.prototype.toString = function() {
-  return 'Maybe.Just(' + R.toString(this.value) + ')';
+  return 'Maybe.Just(' + toString(this.value) + ')';
 };
 
 _Nothing.prototype.toString = function() {

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -1,4 +1,8 @@
-var R = require('ramda');
+var always = require('ramda/src/always');
+var compose = require('ramda/src/compose');
+var equals = require('ramda/src/equals');
+var identity = require('ramda/src/identity');
+var toString = require('ramda/src/toString');
 
 
 function Reader(run) {
@@ -38,10 +42,10 @@ Reader.prototype.of = function(a) {
 };
 Reader.of = Reader.prototype.of;
 
-Reader.ask = Reader(R.identity);
+Reader.ask = Reader(identity);
 
 Reader.prototype.toString = function() {
-  return 'Reader(' + R.toString(this.run) + ')';
+  return 'Reader(' + toString(this.run) + ')';
 };
 
 Reader.T = function(M) {
@@ -52,7 +56,7 @@ Reader.T = function(M) {
     this.run = run;
   };
 
-  ReaderT.lift = R.compose(ReaderT, R.always);
+  ReaderT.lift = compose(ReaderT, always);
 
   ReaderT.ask = ReaderT(M.of);
 
@@ -88,11 +92,11 @@ Reader.T = function(M) {
   ReaderT.prototype.equals = function(that) {
     return this === that ||
       this.run === that.run ||
-      R.equals(this.run().get(), that.run().get());
+      equals(this.run().get(), that.run().get());
   };
 
   ReaderT.prototype.toString = function() {
-    return 'ReaderT[' + M.name + '](' + R.toString(this.run) + ')';
+    return 'ReaderT[' + M.name + '](' + toString(this.run) + ')';
   };
 
   return ReaderT;

--- a/src/Tuple.js
+++ b/src/Tuple.js
@@ -1,4 +1,5 @@
-var R = require('ramda');
+var equals = require('ramda/src/equals');
+var toString = require('ramda/src/toString');
 
 
 function Tuple(x, y) {
@@ -23,7 +24,7 @@ function _Tuple(x, y) {
 function ensureConcat(xs) {
   xs.forEach(function(x) {
     if (typeof x.concat != 'function') {
-      throw new TypeError(R.toString(x) + ' must be a semigroup to perform this operation');
+      throw new TypeError(toString(x) + ' must be a semigroup to perform this operation');
     }
   });
 }
@@ -55,11 +56,11 @@ _Tuple.prototype.ap = function(m) {
 
 // setoid
 _Tuple.prototype.equals = function(that) {
-  return that instanceof _Tuple && R.equals(this[0], that[0]) && R.equals(this[1], that[1]);
+  return that instanceof _Tuple && equals(this[0], that[0]) && equals(this[1], that[1]);
 };
 
 _Tuple.prototype.toString = function() {
-  return 'Tuple(' + R.toString(this[0]) + ', ' + R.toString(this[1]) + ')';
+  return 'Tuple(' + toString(this[0]) + ', ' + toString(this[1]) + ')';
 };
 
 module.exports = Tuple;

--- a/src/internal/util.js
+++ b/src/internal/util.js
@@ -1,4 +1,4 @@
-var _equals = require('ramda').equals;
+var _equals = require('ramda/src/equals');
 
 
 module.exports = {

--- a/src/lift2.js
+++ b/src/lift2.js
@@ -1,5 +1,5 @@
-var R = require('ramda');
+var curryN = require('ramda/src/curryN');
 
-module.exports = R.curryN(3, function lift2(f, a1, a2) {
+module.exports = curryN(3, function lift2(f, a1, a2) {
   return a1.map(f).ap(a2);
 });

--- a/src/lift3.js
+++ b/src/lift3.js
@@ -1,5 +1,5 @@
-var R = require('ramda');
+var curryN = require('ramda/src/curryN');
 
-module.exports = R.curryN(4, function lift3(f, a1, a2, a3) {
+module.exports = curryN(4, function lift3(f, a1, a2, a3) {
   return a1.map(f).ap(a2).ap(a3);
 });


### PR DESCRIPTION
Slim down browserify-based environments by cherry-picking the needed
requirements from Ramda rather than pulling in the whole thing.

Style should be consistent with Ramda-proper's source.