### PR TITLE
bower.json sugar for semver and recommended main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,7 @@
       "name": "Ludwig Magnusson"
     }
   ],
+  "main": "index.js",
   "homepage": "https://www.github.com/ramda/ramda-fantasy",
   "license": "MIT",
   "moduleType": [
@@ -29,7 +30,7 @@
     "type"
   ],
   "dependencies": {
-    "ramda": "^0.14.0"
+    "ramda": "0.1.x"
   },
   "devDependencies": {
     "jshint": "~2.7.0",

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "type"
   ],
   "dependencies": {
-    "ramda": "0.1.x"
+    "ramda": ">=0.1.4"
   },
   "devDependencies": {
     "jshint": "~2.7.0",


### PR DESCRIPTION
This should work. Using sugar/2.0 additional syntax of `0.1.x` over `~1.0` as it is less clear imho, should work as well. Also added `main` to bower.json, recommended but not used directly though - build tools may in fact (and e.g. bower-requirejs likes it a lot too since this is an unambiguous application end-point. 
#106 