### PR TITLE
Create a join method

### DIFF
--- a/src/internal/util.js
+++ b/src/internal/util.js
@@ -62,6 +62,15 @@ module.exports = {
         return Type.of(f(a));
       });
     };
+  },
+  
+  getJoinForTypes : function(m) {
+  return function() {
+    return this.value instanceof m
+      ? this.value.join()
+      : m.of(this.value);
+    }
   }
+
 
 };


### PR DESCRIPTION
I think it would be good for the types to have a join method. Here is a simple implementation.

Obviously used like this:

```js
Maybe.prototype.join = getJoinForTypes(Maybe);
IO.prototype.join = getJoinForTypes(IO)
etc...
```