### PR TITLE
readme: update recommended replacement for Identity type

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Specifically, we suggest these replacements:
 * Tuple: [fantasyland/fantasy-tuples](https://github.com/fantasyland/fantasy-tuples)
 * Reader: [fantasyland/fantasy-readers](https://github.com/fantasyland/fantasy-readers)
 * IO: [fantasyland/fantasy-io](https://github.com/fantasyland/fantasy-io)
-* Identity: [fantasyland/fantasy-identities](https://github.com/fantasyland/fantasy-identities)
+* Identity: [sanctuary-js/sanctuary-identity](https://github.com/sanctuary-js/sanctuary-identity)
 
 ## Available types
 


### PR DESCRIPTION
The currently recommended library has not been updated to use prefixed method names, so this should be uncontroversial. Still, I'd like to get approval from a contributor before merging this pull request.
